### PR TITLE
Fix dead links in readme

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -130,7 +130,7 @@ Nginx UI 可在以下平台中使用：
 - Dragonfly BSD
 - Openwrt
 
-您可以在 [最新发行 (latest release)](https://github.com/0xJacky/nginx-ui/releases/latest) 中下载最新版本，或使用 [Linux 安装脚本](#scripts-for-linux)。
+您可以在 [最新发行 (latest release)](https://github.com/0xJacky/nginx-ui/releases/latest) 中下载最新版本，或使用 [Linux 安装脚本](https://github.com/0xJacky/nginx-ui/blob/master/install.sh)。
 
 ### 使用方法
 
@@ -155,7 +155,7 @@ nohup ./nginx-ui -config app.ini &
 kill -9 $(ps -aux | grep nginx-ui | grep -v grep | awk '{print $2}')
 ```
 #### 使用 Systemd
-如果你使用的是[Linux 安装脚本](#scripts-for-linux)，Nginx UI 将作为 `nginx-ui` 服务安装在 systemd 中。请使用 `systemctl` 命令控制。
+如果你使用的是[Linux 安装脚本](https://github.com/0xJacky/nginx-ui/blob/master/install.sh)，Nginx UI 将作为 `nginx-ui` 服务安装在 systemd 中。请使用 `systemctl` 命令控制。
 
 **启动 Nginx UI**
 

--- a/README-zh_TW.md
+++ b/README-zh_TW.md
@@ -132,7 +132,7 @@ Nginx UI 可在以下作業系統中使用：
 - Dragonfly BSD
 - Openwrt
 
-您可以在 [最新释出 (latest release)](https://github.com/0xJacky/nginx-ui/releases/latest) 中下載最新版本，或使用 [Linux 安裝指令碼](#scripts-for-linux)。
+您可以在 [最新释出 (latest release)](https://github.com/0xJacky/nginx-ui/releases/latest) 中下載最新版本，或使用 [Linux 安裝指令碼](https://github.com/0xJacky/nginx-ui/blob/master/install.sh)。
 
 ### 使用方法
 
@@ -157,7 +157,7 @@ nohup ./nginx-ui -config app.ini &
 kill -9 $(ps -aux | grep nginx-ui | grep -v grep | awk '{print $2}')
 ```
 #### 使用 Systemd
-如果你使用的是 [Linux 安裝指令碼](#scripts-for-linux)，Nginx UI 將作為 `nginx-ui` 守護行程安裝在 systemd 中。請使用 `systemctl` 指令控制。
+如果你使用的是 [Linux 安裝指令碼](https://github.com/0xJacky/nginx-ui/blob/master/install.sh)，Nginx UI 將作為 `nginx-ui` 守護行程安裝在 systemd 中。請使用 `systemctl` 指令控制。
 
 **啟動 Nginx UI**
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Nginx UI is available on the following platforms:
 - Dragonfly BSD
 - Openwrt
 
-You can visit [latest release](https://github.com/0xJacky/nginx-ui/releases/latest) to download the latest distribution, or just use [installation scripts for Linux](#scripts-for-linux).
+You can visit [latest release](https://github.com/0xJacky/nginx-ui/releases/latest) to download the latest distribution, or just use [installation scripts for Linux](https://github.com/0xJacky/nginx-ui/blob/master/install.sh).
 
 ### Usage
 
@@ -158,7 +158,7 @@ Stop Nginx UI with the follow commond.
 kill -9 $(ps -aux | grep nginx-ui | grep -v grep | awk '{print $2}')
 ```
 #### With Systemd
-If you are using the [installation script for Linux](#scripts-for-linux), the Nginx UI will be installed as `nginx-ui` service in systemd. Please use the `systemctl` command to control it.
+If you are using the [installation script for Linux](https://github.com/0xJacky/nginx-ui/blob/master/install.sh), the Nginx UI will be installed as `nginx-ui` service in systemd. Please use the `systemctl` command to control it.
 
 **Start Nginx UI**
 


### PR DESCRIPTION
Fix dead links (the links of "installation script for Linux") in readme.

Signed-off-by: loheagn <loheagn@icloud.com>