### PR TITLE
fix: directive editor background and `Modal` in dark mode

### DIFF
--- a/app/src/language/LINGUAS
+++ b/app/src/language/LINGUAS
@@ -1,1 +1,1 @@
-es fr_FR ru_RU vi_VN zh_CN zh_TW
+en zh_CN zh_TW fr_FR es ru_RU vi_VN

--- a/app/src/views/domain/ngx_conf/NgxConfigEditor.vue
+++ b/app/src/views/domain/ngx_conf/NgxConfigEditor.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useGettext } from 'vue3-gettext'
-import Modal from 'ant-design-vue/lib/modal'
+import { Modal } from 'ant-design-vue'
 import type { ComputedRef } from 'vue'
 import CodeEditor from '@/components/CodeEditor/CodeEditor.vue'
 import template from '@/api/template'

--- a/app/src/views/domain/ngx_conf/NgxServer.vue
+++ b/app/src/views/domain/ngx_conf/NgxServer.vue
@@ -3,7 +3,7 @@
 import { MoreOutlined, PlusOutlined } from '@ant-design/icons-vue'
 import { useGettext } from 'vue3-gettext'
 import type { ComputedRef, Ref } from 'vue'
-import Modal from 'ant-design-vue/lib/modal'
+import { Modal } from 'ant-design-vue'
 import LogEntry from '@/views/domain/ngx_conf/LogEntry.vue'
 import ConfigTemplate from '@/views/domain/ngx_conf/config_template/ConfigTemplate.vue'
 import LocationEditor from '@/views/domain/ngx_conf/LocationEditor.vue'

--- a/app/src/views/domain/ngx_conf/NgxUpstream.vue
+++ b/app/src/views/domain/ngx_conf/NgxUpstream.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { MoreOutlined, PlusOutlined } from '@ant-design/icons-vue'
 import { useGettext } from 'vue3-gettext'
-import Modal from 'ant-design-vue/lib/modal'
+import { Modal } from 'ant-design-vue'
 import _ from 'lodash'
 import type { NgxConfig, NgxDirective } from '@/api/ngx'
 import DirectiveEditor from '@/views/domain/ngx_conf/directive/DirectiveEditor.vue'

--- a/app/src/views/domain/ngx_conf/directive/DirectiveEditorItem.vue
+++ b/app/src/views/domain/ngx_conf/directive/DirectiveEditorItem.vue
@@ -145,13 +145,20 @@ const currentIdx = inject('current_idx')
 
 .directive-editor-extra {
   background-color: #fafafa;
+  border-radius: 5px;
   padding: 10px 20px;
-  margin-bottom: 10px;
+  margin: 10px 0;
 
   .save-btn {
     display: flex;
     justify-content: flex-end;
     margin-top: 15px;
+  }
+}
+
+.dark {
+  .directive-editor-extra {
+    background-color: #1f1f1f;
   }
 }
 


### PR DESCRIPTION
修复了前端深色模式下的两个问题：

1. 有 3 处 `Modal` 的导入方式不对，导致在深色模式下 Modal 还是浅色

<img width="533" alt="截屏2024-01-29 11 46 06" src="https://github.com/0xJacky/nginx-ui/assets/62269186/d3bbe3e0-63b7-4840-9cfc-66c327774429">

2. 编辑站点的“指令”部分的注释背景没有适配深色模式

<img width="1262" alt="image" src="https://github.com/0xJacky/nginx-ui/assets/62269186/a656ae24-5fbc-46a6-9d1e-80fe7d740391">

（顺便问一下，Modal 不加背景遮罩是有什么考虑吗？个人感觉层级有点不明显，并且其它一些地方的一些 Modal 又有遮罩