### PR TITLE
fix: stream is not deleted actually

### DIFF
--- a/api/streams/streams.go
+++ b/api/streams/streams.go
@@ -345,6 +345,11 @@ func DeleteStream(c *gin.Context) {
 		return
 	}
 
+	if err = os.Remove(availablePath); err != nil {
+		api.ErrHandler(c, err)
+		return
+	}
+
 	c.JSON(http.StatusOK, gin.H{
 		"message": "ok",
 	})


### PR DESCRIPTION
delete stream api didn't actually delete the stream actually.
It only checked the file existed and return 200 ok.