### PR TITLE
fix: http-to-https use $host and 308

### DIFF
--- a/template/block/http-to-https.conf
+++ b/template/block/http-to-https.conf
@@ -11,9 +11,9 @@ value = ""
 
 {{- if .host }}
     if ($host == {{ .host }}) {
-        return 307 https://$server_name$request_uri;
+        return 301 https://$host$request_uri;
     }
     return 404;
 {{ else }}
-return 307 https://$server_name$request_uri;
+return 301 https://$host$request_uri;
 {{- end }}

--- a/template/block/http-to-https.conf
+++ b/template/block/http-to-https.conf
@@ -11,9 +11,9 @@ value = ""
 
 {{- if .host }}
     if ($host == {{ .host }}) {
-        return 301 https://$host$request_uri;
+        return 308 https://$host$request_uri;
     }
     return 404;
 {{ else }}
-return 301 https://$host$request_uri;
+return 308 https://$host$request_uri;
 {{- end }}


### PR DESCRIPTION
使用 $server_name 在使用通配符域名等情况下无法跳转，建议使用 $host。
强制HTTPS我觉得应该是永久重定向比较好吧。