### PR TITLE
fix: background color of `BatchUpgrader` in dark mode

### DIFF
--- a/app/src/views/environment/BatchUpgrader.vue
+++ b/app/src/views/environment/BatchUpgrader.vue
@@ -239,16 +239,18 @@ async function performUpgrade() {
   </AModal>
 </template>
 
-<style scoped lang="less">
+<style lang="less">
 .dark {
-  :deep(.core-upgrade-log-container) {
+  .core-upgrade-log-container {
     background-color: rgba(0, 0, 0, 0.84);
   }
 }
+</style>
 
+<style scoped lang="less">
 :deep(.core-upgrade-log-container) {
   height: 320px;
-  overflow: scroll;
+  overflow-y: auto;
   background-color: #f3f3f3;
   border-radius: 4px;
   margin-top: 15px;


### PR DESCRIPTION
修复了“批量升级环境”对话框在深色模式下的背景。

<img width="303" alt="image" src="https://github.com/user-attachments/assets/514be565-4831-4bfd-833d-bdbbbb8d06be">

<img width="303" alt="image" src="https://github.com/user-attachments/assets/b98eb25f-7914-4175-acf7-a7ebe5fdf571">

