### PR TITLE
fix: background color of `BatchUpgrader` in dark mode

### DIFF
--- a/app/src/views/environment/BatchUpgrader.vue
+++ b/app/src/views/environment/BatchUpgrader.vue
@@ -242,7 +242,7 @@ async function performUpgrade() {
 <style lang="less">
 .dark {
   .core-upgrade-log-container {
-    background-color: rgba(0, 0, 0, 0.84);
+    background-color: rgba(0, 0, 0, 0.84) !important;
   }
 }
 </style>


### PR DESCRIPTION
#554 修复了“批量升级环境”对话框在深色模式下的背景。

之前的没修干净。重新修复后已经打包部署到 VPS 上验证通过。