### PR TITLE
Use redirect instead of rewrite for reverse proxy example

### DIFF
--- a/docs/guide/nginx-proxy-example.md
+++ b/docs/guide/nginx-proxy-example.md
@@ -9,7 +9,7 @@ server {
     listen          [::]:80;
 
     server_name     <your_server_name>;
-    rewrite ^(.*)$  https://$host$1 permanent;
+    return 301 https://$host$request_uri;
 }
 
 map $http_upgrade $connection_upgrade {


### PR DESCRIPTION
According to http://nginx.org/en/docs/http/converting_rewrite_rules.html this is the better way to implement redirects. It is easier to parse and understand.