### PR TITLE
chore: add `loongarch64` build

### DIFF
--- a/.github/build/build_info.json
+++ b/.github/build/build_info.json
@@ -6,6 +6,7 @@
         "arm6": {"arch": "armv5l", "abi": "eabihf", "name": "linux-arm32-v6"},
         "arm7": {"arch": "armv7l", "abi": "eabihf", "name": "linux-arm32-v7a"},
         "arm64": {"arch": "aarch64", "name": "linux-arm64-v8a"},
+        "loong64": {"arch": "loongarch64", "name": "linux-loong64"},
         "riscv64": {"arch": "riscv64", "name": "linux-riscv64"},
         "mips64le": { "arch": "mips64el", "name": "linux-mips64le" },
         "mips64": { "arch": "mips64", "name": "linux-mips64" },

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,6 +116,8 @@ jobs:
           # END Linux ARM 5 6 7
           - goos: linux
             goarch: riscv64
+          - goos: linux
+            goarch: loong64
           # BEGIN MIPS
           - goos: linux
             goarch: mips64
@@ -155,10 +157,11 @@ jobs:
 
       - name: Install musl cross compiler
         if: env.GOOS == 'linux'
-        uses: 0xJacky/musl-cross-compilers@v0.6.6
+        uses: nginxui/musl-cross-compilers@v1
         id: musl
         with:
           target: ${{ env.ARCH_NAME }}-linux-musl${{ env.ABI }}
+          variant: ${{ env.GOARCH == 'loong64' && 'userdocs/qbt-musl-cross-make' || 'richfelker/musl-cross-make' }}
 
       - name: Post install musl cross compiler
         if: env.GOOS == 'linux'


### PR DESCRIPTION
We have tested the `loongarch64` version on the qemu simulator.

Related project: https://github.com/nginxui/musl-cross-compilers

![image](https://github.com/user-attachments/assets/a77c1f7f-611f-4808-9b8d-4d420f1d2639)