### PR TITLE
feat: 配置管理页面将文件夹和文件分开排序，默认以name字段，升序排序

### DIFF
--- a/api/config/list.go
+++ b/api/config/list.go
@@ -39,8 +39,8 @@ func (c *FileEntity) GetNamespace() *model.Namespace {
 
 func GetConfigs(c *gin.Context) {
 	search := c.Query("search")
-	sortBy := c.Query("sort_by")
-	order := c.DefaultQuery("order", "desc")
+	sortBy := c.DefaultQuery("sort_by", "name")
+	order := c.DefaultQuery("order", "asc")
 	namespaceIDStr := c.Query("env_group_id")
 
 	// Get directory parameter

--- a/app/src/views/config/configColumns.tsx
+++ b/app/src/views/config/configColumns.tsx
@@ -17,6 +17,7 @@ const configColumns: StdTableColumn[] = [{
   title: () => $gettext('Name'),
   dataIndex: 'name',
   sorter: true,
+  sortDirections: ['descend', 'ascend'],
   pure: true,
   customRender: ({ text, record }: CustomRenderArgs) => {
     function renderIcon(isDir: boolean) {

--- a/internal/config/config_list.go
+++ b/internal/config/config_list.go
@@ -33,12 +33,15 @@ func (c ConfigsSort) Less(i, j int) bool {
 		flag = c.ConfigList[i].Name > c.ConfigList[j].Name
 	case "modified_at":
 		flag = c.ConfigList[i].ModifiedAt.After(c.ConfigList[j].ModifiedAt)
-	case "is_dir":
-		flag = boolToInt(c.ConfigList[i].IsDir) > boolToInt(c.ConfigList[j].IsDir)
 	case "status":
 		flag = c.ConfigList[i].Status > c.ConfigList[j].Status
 	case "namespace_id":
 		flag = c.ConfigList[i].NamespaceID > c.ConfigList[j].NamespaceID
+	}
+
+	if c.ConfigList[i].IsDir != c.ConfigList[j].IsDir {
+		// Sort folders and files separately
+		flag = boolToInt(c.ConfigList[i].IsDir) < boolToInt(c.ConfigList[j].IsDir)
 	}
 
 	if c.Order == "asc" {


### PR DESCRIPTION
图示如下：
![2025_08_29_11_36_13](https://github.com/user-attachments/assets/c5243a63-2100-4701-8353-39fca709f768)
