### PR TITLE
Fix Windows reload issue (/bin/sh not found)

### DIFF
--- a/internal/nginx/exec.go
+++ b/internal/nginx/exec.go
@@ -3,13 +3,28 @@ package nginx
 import (
 	"context"
 	"os/exec"
+	"runtime"
 
 	"github.com/0xJacky/Nginx-UI/internal/docker"
 	"github.com/0xJacky/Nginx-UI/settings"
 )
 
 func execShell(cmd string) (stdOut string, stdErr error) {
-	return execCommand("/bin/sh", "-c", cmd)
+	var execCmd *exec.Cmd
+
+	if runtime.GOOS == "windows" {
+		execCmd = exec.Command("cmd", "/c", cmd)
+	} else {
+		execCmd = exec.Command("/bin/sh", "-c", cmd)
+	}
+
+	execCmd.Dir = GetNginxExeDir()
+	bytes, err := execCmd.CombinedOutput()
+	stdOut = string(bytes)
+	if err != nil {
+		stdErr = err
+	}
+	return
 }
 
 func execCommand(name string, cmd ...string) (stdOut string, stdErr error) {


### PR DESCRIPTION
This PR adds native Windows compatibility for Nginx-UI, fixing the following error when reloading Nginx on
Windows:
```
Nginx error: exec: "/bin/sh": executable file not found in %PATH%
```

Updated execShell in internal/nginx/exec.go
to use cmd /C instead of /bin/sh -c when running on Windows.

This makes ReloadCmd, RestartCmd, and other Nginx commands work properly on Windows environments.

# Implementation Detail

``` go
func execShell(cmd string) (stdOut string, stdErr error) {
    if runtime.GOOS == "windows" {
        return execCommand("cmd", "/C", cmd)
    }
    return execCommand("/bin/sh", "-c", cmd)
}
```

Added import "runtime" for OS detection.

# Tested Environment

OS: Windows 10 / Windows Server 2019

Nginx: Windows build (nginx.exe)

Result:

Reload and Restart work correctly

UI responds successfully

No /bin/sh errors