### PR TITLE
Fix: Move http2 directive inside listen to resolve “unknown directive http2” error

### DIFF
--- a/docs/guide/nginx-proxy-example.md
+++ b/docs/guide/nginx-proxy-example.md
@@ -18,9 +18,8 @@ map $http_upgrade $connection_upgrade {
 }
 
 server {
-    listen  443       ssl;
-    listen  [::]:443  ssl;
-    http2   on;
+    listen  443       ssl  http2;
+    listen  [::]:443  ssl  http2;
 
     server_name         <your_server_name>;
 


### PR DESCRIPTION
# Summary
This PR updates the NGINX configuration to correctly enable HTTP/2 by moving the http2 directive inside the listen statement.
Previously, using http2 as a standalone directive caused:
```
nginx: [emerg] unknown directive "http2" in /etc/nginx/sites-enabled/default:XX
```
# Problem
The original configuration:
```
server {
    listen 443 ssl;
    listen [::]:443 ssl;
    http2 on;

    ...
}
```
Using http2 as a separate directive is **not supported by NGINX**.
This breaks the reverse proxy setup, especially for services that require WebSocket or HTTP/2.
# Solution
The http2 directive is now placed correctly inside the listen statement:
```
server {
    listen 443 ssl http2;
    listen [::]:443 ssl http2;

    ...
}
```
This ensures proper HTTP/2 support and removes the startup error.