### PR TITLE
Add support for custom Nginx maintenance templates (NGINX_UI_NGINX_MAINTENANCE_TEMPLATE / Settings > Nginx)

### DIFF
--- a/api/pages/maintenance.go
+++ b/api/pages/maintenance.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/0xJacky/Nginx-UI/settings"

--- a/api/pages/maintenance.go
+++ b/api/pages/maintenance.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"html/template"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/0xJacky/Nginx-UI/settings"
@@ -53,7 +54,15 @@ func MaintenancePage(c *gin.Context) {
 		return
 	}
 
-	// Parse template
+	// Try custom mounted HTML first (NGINX_UI_NGINX_MAINTENANCE_TEMPLATE)
+	if custom := strings.TrimSpace(settings.NginxSettings.MaintenanceTemplate); custom != "" {
+		if b, err := os.ReadFile(custom); err == nil {
+			c.Data(http.StatusServiceUnavailable, "text/html; charset=utf-8", b)
+			return
+		}
+	}
+
+	// Fallback: embedded template
 	tmpl, err := template.ParseFS(tmplFS, "maintenance.tmpl")
 	if err != nil {
 		c.String(http.StatusInternalServerError, "503 Service Unavailable")

--- a/api/pages/maintenance.go
+++ b/api/pages/maintenance.go
@@ -14,6 +14,8 @@ import (
 //go:embed *.tmpl
 var tmplFS embed.FS
 
+const maintenanceMountDir = "/etc/nginx/maintenance"
+
 // MaintenancePageData maintenance page data structure
 type MaintenancePageData struct {
 	Title                string `json:"title"`
@@ -55,8 +57,11 @@ func MaintenancePage(c *gin.Context) {
 	}
 
 	// Try custom mounted HTML first (NGINX_UI_NGINX_MAINTENANCE_TEMPLATE)
-	if custom := strings.TrimSpace(settings.NginxSettings.MaintenanceTemplate); custom != "" {
-		if b, err := os.ReadFile(custom); err == nil {
+	if name := strings.TrimSpace(settings.NginxSettings.MaintenanceTemplate); name != "" {
+		name = filepath.Base(name)
+		full := filepath.Join(maintenanceMountDir, name)
+
+		if b, err := os.ReadFile(full); err == nil && len(b) > 0 {
 			c.Data(http.StatusServiceUnavailable, "text/html; charset=utf-8", b)
 			return
 		}

--- a/app/src/api/settings.ts
+++ b/app/src/api/settings.ts
@@ -68,6 +68,7 @@ export interface NginxSettings {
   restart_cmd: string
   stub_status_port: number
   container_name: string
+  maintenance_template?: string
 }
 
 export interface NginxLogSettings {

--- a/app/src/views/preference/tabs/NginxSettings.vue
+++ b/app/src/views/preference/tabs/NginxSettings.vue
@@ -10,6 +10,16 @@ const { data } = storeToRefs(systemSettingsStore)
     <AFormItem :label="$gettext('Stub Status Port')">
       <AInputNumber v-model:value="data.nginx.stub_status_port" />
     </AFormItem>
+    <AFormItem
+      :label="$gettext('Maintenance Template Path')"
+      :help="$gettext('Absolute path to a custom maintenance HTML file (e.g., /etc/nginx/maintenance/enwikuna-maintenance.html). Leave empty to use the built-in template.')"
+    >
+      <AInput
+        v-model:value="data.nginx.maintenance_template"
+        :placeholder="$gettext('e.g., /etc/nginx/maintenance/enwikuna-maintenance.html')"
+        allowClear
+      />
+    </AFormItem>
     <AFormItem :label="$gettext('Nginx Access Log Path')">
       {{ data.nginx.access_log_path }}
     </AFormItem>

--- a/app/src/views/preference/tabs/NginxSettings.vue
+++ b/app/src/views/preference/tabs/NginxSettings.vue
@@ -13,7 +13,7 @@ const { data } = storeToRefs(systemSettingsStore)
     <AFormItem :label="$gettext('Maintenance template (filename only)')">
       <AInput
         v-model:value="data.nginx.maintenance_template"
-        :placeholder="$gettext('enwikuna-maintenance.html')" />
+        :placeholder="$gettext('maintenance.html')" />
       <div class="text-secondary mt-1">
         {{$gettext('Mounted directory')}}: /etc/nginx/maintenance
       </div>

--- a/app/src/views/preference/tabs/NginxSettings.vue
+++ b/app/src/views/preference/tabs/NginxSettings.vue
@@ -10,15 +10,13 @@ const { data } = storeToRefs(systemSettingsStore)
     <AFormItem :label="$gettext('Stub Status Port')">
       <AInputNumber v-model:value="data.nginx.stub_status_port" />
     </AFormItem>
-    <AFormItem
-      :label="$gettext('Maintenance Template Path')"
-      :help="$gettext('Absolute path to a custom maintenance HTML file (e.g., /etc/nginx/maintenance/enwikuna-maintenance.html). Leave empty to use the built-in template.')"
-    >
+    <AFormItem :label="$gettext('Maintenance template (filename only)')">
       <AInput
         v-model:value="data.nginx.maintenance_template"
-        :placeholder="$gettext('e.g., /etc/nginx/maintenance/enwikuna-maintenance.html')"
-        allowClear
-      />
+        :placeholder="$gettext('enwikuna-maintenance.html')" />
+      <div class="text-secondary mt-1">
+        {{$gettext('Mounted directory')}}: /etc/nginx/maintenance
+      </div>
     </AFormItem>
     <AFormItem :label="$gettext('Nginx Access Log Path')">
       {{ data.nginx.access_log_path }}

--- a/settings/nginx.go
+++ b/settings/nginx.go
@@ -13,6 +13,7 @@ type Nginx struct {
 	RestartCmd               string   `json:"restart_cmd" protected:"true"`
 	StubStatusPort           uint     `json:"stub_status_port" binding:"omitempty,min=1,max=65535"`
 	ContainerName            string   `json:"container_name" protected:"true"`
+	MaintenanceTemplate      string   `json:"maintenance_template"`
 }
 
 var NginxSettings = &Nginx{}


### PR DESCRIPTION
- Add/use environment variable NGINX_UI_NGINX_MAINTENANCE_TEMPLATE to point the app to a custom maintenance HTML template used when maintenance mode is enabled.
- Allow the maintenance template path to be configured from the web UI as well: Settings > Nginx.
- If a custom path is provided (env var or UI), the app will load that file from inside the container. If not provided, the built-in default template is used.
- Document how to provide custom templates by mounting a host directory into the container:
  - Example mount: ./nginx:/etc/nginx
  - Create a maintenance folder inside that mount: ./nginx/maintenance
  - Put your template file there, e.g. ./nginx/maintenance/maintenance.html
  - Set the template path to the absolute path inside the container:
    NGINX_UI_NGINX_MAINTENANCE_TEMPLATE=/etc/nginx/maintenance/maintenance.html
- Notes:
  - The path must be the absolute path inside the container and the file must be readable by the nginx process (e.g., mode 644).
  - After changing the env var or updating templates (or changing the setting in Settings > Nginx), restart the container or reload nginx for changes to take effect.
  - You can store multiple templates under ./nginx/maintenance and switch between them by updating the env var or the UI setting.
- Include example docker-compose snippet in docs:
  volumes:
    - ./nginx:/etc/nginx
  environment:
    - NGINX_UI_NGINX_MAINTENANCE_TEMPLATE=/etc/nginx/maintenance/maintenance.html

This commit adds configuration surface and documentation for using custom maintenance templates via environment variable or the UI.

<img width="913" height="280" alt="image" src="https://github.com/user-attachments/assets/130349d9-a03c-4f2d-85b3-7621a940f617" />

<img width="1339" height="630" alt="image" src="https://github.com/user-attachments/assets/81a42b3b-cd68-4bb6-ba79-85d75eacc993" />

```
services:
  nginx-ui:
    image: nginx-ui-fixed:local
    container_name: nginx-ui
    restart: always
    stdin_open: true
    tty: true
    environment:
      - TZ=Europe/Berlin
      - GIN_MODE=release
      - NGINX_UI_NGINX_MAINTENANCE_TEMPLATE=enwikuna-maintenance.html
```

 Kindly ask you to test and merge our changes into production line.