### PR TITLE
Investigate nginx-ui issue 1446

### DIFF
--- a/internal/sitecheck/checker_test.go
+++ b/internal/sitecheck/checker_test.go
@@ -1,0 +1,48 @@
+package sitecheck
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/0xJacky/Nginx-UI/model"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestCheckSiteSkipsNetworkWhenDisabled(t *testing.T) {
+	t.Cleanup(InvalidateSiteConfigCache)
+
+	options := DefaultCheckOptions()
+	checker := NewSiteChecker(options)
+
+	// Any HTTP request made by the checker should fail this test.
+	checker.client = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			t.Fatalf("unexpected HTTP request to %s while health check is disabled", req.URL.String())
+			return nil, nil
+		}),
+	}
+
+	const siteURL = "https://example.com"
+	config := &model.SiteConfig{
+		Model:              model.Model{ID: 1},
+		Host:               "example.com:443",
+		Scheme:             "https",
+		DisplayURL:         siteURL,
+		HealthCheckEnabled: false,
+		HealthCheckConfig: &model.HealthCheckConfig{
+			Protocol: "https",
+		},
+	}
+
+	setCachedSiteConfig(config.Host, config)
+
+	if _, err := checker.CheckSite(context.Background(), siteURL); err != nil {
+		t.Fatalf("CheckSite returned error: %v", err)
+	}
+}


### PR DESCRIPTION
Prevent disabled site health checks from making network requests to fix issue #1446.

Even when health checks were disabled, the `tryGetFavicon` function would implicitly trigger HTTP GET requests, leading to unexpected traffic. This PR ensures that when health checks are disabled, cached site metadata is returned immediately without any network activity.

---
<a href="https://cursor.com/background-agent?bcId=bc-577bb3c0-699c-4e68-b2ab-9685bf68e0b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-577bb3c0-699c-4e68-b2ab-9685bf68e0b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> When health checks are disabled, return cached site metadata without making HTTP requests, leveraging a snapshot of prior site info and adding a unit test to enforce this.
> 
> - **Backend (sitecheck)**:
>   - **Behavior change**: `CheckSite` now returns cached metadata when `HealthCheckEnabled` is false, avoiding favicon fetches and all network calls; populates fields from an existing site snapshot if available.
>   - **Utility**: Adds `getExistingSiteSnapshot` with read-locking to safely clone prior `SiteInfo`.
> - **Tests**:
>   - Adds `TestCheckSiteSkipsNetworkWhenDisabled` to ensure no HTTP requests occur when health checks are disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54d276447ed24ebebfd1425cf21ce653a49ecb9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->