### PR TITLE
feat: allow full HTTP status codes for health checks

### DIFF
--- a/app/src/views/dashboard/components/SiteHealthCheckModal.vue
+++ b/app/src/views/dashboard/components/SiteHealthCheckModal.vue
@@ -131,7 +131,7 @@ const statusCodeGroups: StatusCodeGroup[] = [
       createStatusOption(415, 'Unsupported Media Type'),
       createStatusOption(416, 'Range Not Satisfiable'),
       createStatusOption(417, 'Expectation Failed'),
-      createStatusOption(418, "I'm a teapot"),
+      createStatusOption(418, 'I\'m a teapot'),
       createStatusOption(421, 'Misdirected Request'),
       createStatusOption(422, 'Unprocessable Content'),
       createStatusOption(423, 'Locked'),


### PR DESCRIPTION
Add `401 Unauthorized` to the health check's expected status codes dropdown.

This allows sites requiring authentication to correctly configure `401 Unauthorized` as an expected status, preventing them from being mistakenly flagged as unhealthy.

---
<a href="https://cursor.com/background-agent?bcId=bc-399947a5-c208-487d-a0fb-ec1bb7397df2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-399947a5-c208-487d-a0fb-ec1bb7397df2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands the health check "Expected Status Codes" dropdown to include all grouped HTTP 1xx–5xx codes, replacing hardcoded options.
> 
> - **Frontend**
>   - **`app/src/views/dashboard/components/SiteHealthCheckModal.vue`**:
>     - Add `StatusCodeOption`/`StatusCodeGroup` interfaces and `createStatusOption` helper; define grouped status lists for 1xx–5xx.
>     - Replace hardcoded `ASelectOption`s with grouped options using `ASelectOptGroup` and `v-for` to render all HTTP codes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4e1bee26ab9176dcad5f7e32572f39f6207ad99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->