### PR TITLE
Fix nginx-ui issue 1455

### DIFF
--- a/internal/cron/incremental_indexing_test.go
+++ b/internal/cron/incremental_indexing_test.go
@@ -1,0 +1,108 @@
+package cron
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/0xJacky/Nginx-UI/internal/nginx_log"
+	"github.com/0xJacky/Nginx-UI/internal/nginx_log/indexer"
+	"github.com/0xJacky/Nginx-UI/model"
+)
+
+type stubLogIndexProvider struct {
+	idx *model.NginxLogIndex
+	err error
+}
+
+func (s stubLogIndexProvider) GetLogIndex(path string) (*model.NginxLogIndex, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.idx != nil {
+		s.idx.Path = path
+	}
+	return s.idx, nil
+}
+
+func TestNeedsIncrementalIndexingSkipsWhenUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "access.log")
+	if err := os.WriteFile(logPath, []byte("initial\n"), 0o644); err != nil {
+		t.Fatalf("write temp log: %v", err)
+	}
+
+	info, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatalf("stat temp log: %v", err)
+	}
+
+	persisted := &model.NginxLogIndex{
+		Path:         logPath,
+		LastModified: info.ModTime(),
+		LastSize:     info.Size(),
+		LastIndexed:  time.Now(),
+	}
+
+	logData := &nginx_log.NginxLogWithIndex{
+		Path:         logPath,
+		Type:         "access",
+		IndexStatus:  string(indexer.IndexStatusIndexed),
+		LastModified: info.ModTime().Unix(),
+		LastSize:     info.Size() * 10, // simulate grouped size inflation
+		LastIndexed:  time.Now().Unix(),
+	}
+
+	if needsIncrementalIndexing(logData, stubLogIndexProvider{idx: persisted}) {
+		t.Fatalf("expected no incremental indexing when file metadata is unchanged")
+	}
+}
+
+func TestNeedsIncrementalIndexingDetectsGrowth(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "access.log")
+	if err := os.WriteFile(logPath, []byte("initial\n"), 0o644); err != nil {
+		t.Fatalf("write temp log: %v", err)
+	}
+
+	initialInfo, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatalf("stat temp log: %v", err)
+	}
+
+	persisted := &model.NginxLogIndex{
+		Path:         logPath,
+		LastModified: initialInfo.ModTime().Add(-time.Minute),
+		LastSize:     initialInfo.Size(),
+		LastIndexed:  time.Now().Add(-time.Minute),
+	}
+
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open temp log: %v", err)
+	}
+	if _, err := f.WriteString("more data\n"); err != nil {
+		f.Close()
+		t.Fatalf("append temp log: %v", err)
+	}
+	_ = f.Close()
+
+	finalInfo, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatalf("restat temp log: %v", err)
+	}
+
+	logData := &nginx_log.NginxLogWithIndex{
+		Path:         logPath,
+		Type:         "access",
+		IndexStatus:  string(indexer.IndexStatusIndexed),
+		LastModified: finalInfo.ModTime().Unix(),
+		LastSize:     initialInfo.Size(),
+		LastIndexed:  time.Now().Unix(),
+	}
+
+	if !needsIncrementalIndexing(logData, stubLogIndexProvider{idx: persisted}) {
+		t.Fatalf("expected incremental indexing when file grew")
+	}
+}


### PR DESCRIPTION
Fixes #1455 by using per-file persisted metadata for incremental indexing decisions to prevent unnecessary re-indexing caused by aggregated log sizes.

The previous incremental indexing logic could incorrectly trigger re-indexing due to `log.LastSize` being an aggregated value across rotated log files (e.g., `access.log` and `access.log.1`). This led to false positives where the system believed a file had shrunk or grown, causing infinite rebuilds. This PR injects the actual `PersistenceManager` to use accurate per-file metadata for `LastModified` and `LastSize`, ensuring indexing only occurs when truly needed. A fallback mechanism is also included for cases where persistence data isn't available, clamping the `LastSize` to prevent similar issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-98a269d0-ef88-4297-bfa0-5c088ce6e234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-98a269d0-ef88-4297-bfa0-5c088ce6e234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch incremental indexing to per-file persisted metadata with a safe fallback, add rotation-aware doc count updates, and include unit tests.
> 
> - **Incremental indexing logic**:
>   - Use persistence (`logIndexProvider`) to decide indexing via per-file metadata (`GetLogIndex`/`NeedsIndexing`).
>   - Fallback path clamps aggregated `LastSize`, handles never-indexed files, and refines change detection.
>   - Pass persistence from `LogFileManager` into `needsIncrementalIndexing` and job loop.
> - **Indexing execution** (`queueIncrementalIndexing`):
>   - Detect log rotation by size decrease; reset document count on rotation, otherwise accumulate.
>   - Persist indexing metadata (`SaveIndexMetadata`) and manage statuses via persistence-backed `setFileIndexStatus` with simple queue ordering.
> - **Tests**:
>   - Add `internal/cron/incremental_indexing_test.go` with stub provider covering unchanged file skip and growth detection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e9fa7d0e0cc776648f225cdec097d4cfe7ea00b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->