### PR TITLE
Enhance CLAUDE guidelines and agent linkage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,10 +23,12 @@ This project is a web-based NGINX management interface built with Go backend and
 
 ### Development Guidelines
 - Write concise, maintainable Go code with clear examples
+- Run `gofmt`/`goimports` before committing backend changes
 - Use Gen to streamline database queries and reduce boilerplate
 - Follow Cosy Error Handler best practices for error management
 - Implement standardized CRUD operations using Cosy framework
 - Apply efficient database pagination for large datasets
+- Validate changes with `go test ./... -race -cover` before pushing
 - Keep files modular and well-organized by functionality
 - **All comments and documentation must be in English**
 
@@ -70,10 +72,12 @@ This project is a web-based NGINX management interface built with Go backend and
 
 ### Code Quality
 - **Always use ESLint MCP after generating frontend code** to ensure code quality and consistency
+- Run `pnpm lint`, `pnpm lint:fix`, and `pnpm typecheck` to keep style and typings aligned
 
 ## Development Commands
-- **Frontend**: `pnpm run dev`, `pnpm typecheck`, `pnpm run build`
-- **Backend**: Standard Go commands (`go run`, `go build`, `go test`)
+- **Frontend**: `pnpm run dev`, `pnpm lint`, `pnpm typecheck`, `pnpm run build`
+- **Backend**: `go generate ./...`, `go build ./...`, run `go test ./... -race -cover`; for release artifacts reuse the README command with `-tags=jsoniter -ldflags "$LD_FLAGS ..."`.
+- **Demo stack**: `docker-compose -f docker-compose-demo.yml up` to bootstrap the sample environment
 
 ## Language Requirements
 - **All code comments, documentation, and communication must be in English**


### PR DESCRIPTION
Detail Go formatting and race-safe test expectations for backend work.

List frontend linting commands so CLAUDE matches current workflows.

Link AGENTS.md to CLAUDE.md so other agents reuse the strengthened guide.

GitHub Copilot summary:

> This pull request adds a new documentation file and updates the development guidelines and commands to emphasize code quality, formatting, and testing standards for both backend and frontend development.
> 
> Documentation updates:
> 
> * Added the `CLAUDE.md` file to the project documentation.
> 
> Backend development standards:
> 
> * Updated guidelines to require running `gofmt`/`goimports` for code formatting and validating changes with `go test ./... -race -cover` before pushing.
> * Enhanced backend commands to include `go generate ./...` and more detailed instructions for building and testing, including release artifact generation.
> 
> Frontend development standards:
> 
> * Added instructions to run `pnpm lint`, `pnpm lint:fix`, and `pnpm typecheck` to maintain style and type consistency.
> * Updated frontend commands to include linting and type checking as part of the development workflow.
> 
> Development environment:
> 
> * Added instructions for bootstrapping a demo stack using Docker Compose.