### PR TITLE
Update x-forwarded-proto header handling

### DIFF
--- a/internal/site/index_test.go
+++ b/internal/site/index_test.go
@@ -1,0 +1,54 @@
+package site
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/0xJacky/Nginx-UI/settings"
+)
+
+func TestScanForSiteHandlesWildcardAndProxyProtocol(t *testing.T) {
+	originalConfigDir := settings.NginxSettings.ConfigDir
+	tmpDir := t.TempDir()
+	settings.NginxSettings.ConfigDir = tmpDir
+	t.Cleanup(func() {
+		settings.NginxSettings.ConfigDir = originalConfigDir
+		siteIndexMutex.Lock()
+		delete(IndexedSites, "wildcard.conf")
+		siteIndexMutex.Unlock()
+	})
+
+	configPath := filepath.Join(tmpDir, "wildcard.conf")
+	config := []byte(`
+server {
+    listen 8443 ssl proxy_protocol;
+    server_name *.example.com;
+}
+`)
+
+	if err := scanForSite(configPath, config); err != nil {
+		t.Fatalf("scanForSite returned error: %v", err)
+	}
+
+	siteIndexMutex.RLock()
+	indexed := IndexedSites["wildcard.conf"]
+	siteIndexMutex.RUnlock()
+
+	if indexed == nil {
+		t.Fatal("expected indexed site to be populated")
+	}
+
+	if got := len(indexed.Urls); got != 1 {
+		t.Fatalf("expected 1 URL, got %d", got)
+	}
+
+	rawURL := "https://example.com:8443"
+	if indexed.Urls[0] != rawURL {
+		t.Fatalf("expected raw URL %s, got %s", rawURL, indexed.Urls[0])
+	}
+
+	displayURL := indexed.GetDisplayURL(rawURL)
+	if displayURL != "https://example.com" {
+		t.Fatalf("expected display URL %s, got %s", "https://example.com", displayURL)
+	}
+}

--- a/internal/sitecheck/checker.go
+++ b/internal/sitecheck/checker.go
@@ -119,10 +119,14 @@ func (sc *SiteChecker) CollectSites() {
 					logger.Debugf("Site %s using default protocol: %s (config error: %v)", url, protocol, err)
 				}
 
-				// Parse URL components for legacy fields
+				displayURL := url
+				if friendly := indexedSite.GetDisplayURL(url); friendly != "" {
+					displayURL = friendly
+				}
 
 				// Get or create site config to get ID
 				siteConfig := getOrCreateSiteConfigForURL(url)
+				siteConfig.DisplayURL = displayURL
 
 				siteInfo := &SiteInfo{
 					SiteConfig:  *siteConfig,
@@ -542,6 +546,9 @@ func extractDomainName(siteURL string) string {
 	parsed, err := url.Parse(siteURL)
 	if err != nil {
 		return siteURL
+	}
+	if hostname := parsed.Hostname(); hostname != "" {
+		return hostname
 	}
 	return parsed.Host
 }


### PR DESCRIPTION
Separate site scan's probe URL from display URL and enhance wildcard server_name parsing.

Ensures sites with wildcard server_names and proxy_protocol listeners display correctly and are clickable in the UI, avoiding internal port exposure.

---
<a href="https://cursor.com/background-agent?bcId=bc-faddf333-f3ed-469d-a4bc-6c2dd927e4eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-faddf333-f3ed-469d-a4bc-6c2dd927e4eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

