### PR TITLE
Docker client version update

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -12,11 +12,14 @@ func initClient() (cli *client.Client, err error) {
 	if err != nil {
 		return
 	}
-	// Optionally ping the server to ensure the connection is valid
-	_, err = cli.Ping(context.Background())
+	// Ping the server to ensure the connection is valid and negotiate API version
+	ping, err := cli.Ping(context.Background())
 	if err != nil {
 		return
 	}
+	// Explicitly negotiate API version based on the ping response
+	// This ensures the client uses a compatible API version with the Docker daemon
+	cli.NegotiateAPIVersionPing(ping)
 
 	return
 }


### PR DESCRIPTION
Explicitly negotiate Docker API version to ensure compatibility with older Docker daemon versions.

The `WithAPIVersionNegotiation()` option was enabled, but the manual `cli.Ping()` call in `initClient()` did not trigger the client's internal version negotiation mechanism. This resulted in the client attempting to use its default API version (v1.51) for subsequent calls, leading to "404 Not Found" errors when connecting to older Docker daemons. By explicitly calling `cli.NegotiateAPIVersionPing(ping)` after a successful ping, the client's API version is correctly downgraded to match the daemon's capabilities.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-c80ad23f-9cb9-4208-a670-80f594c5a6fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c80ad23f-9cb9-4208-a670-80f594c5a6fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to Docker client initialization; primary risk is unexpected behavior if `Ping` negotiation differs across daemon/client versions.
> 
> **Overview**
> Ensures the Docker client reliably negotiates a compatible API version with the daemon by capturing the `Ping` response and calling `cli.NegotiateAPIVersionPing(ping)` during `initClient()`.
> 
> This prevents subsequent Docker API calls from using an incompatible default client API version against older daemons (avoiding `404 Not Found` errors).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 562097a532c9d13ba53332138bfce705ae09fca0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->