### PR TITLE
Propfind method logging

### DIFF
--- a/internal/nginx_log/indexer/parallel_indexer_optimized.go
+++ b/internal/nginx_log/indexer/parallel_indexer_optimized.go
@@ -289,8 +289,12 @@ func isValidLogEntry(doc *LogDocument) bool {
 	// Check HTTP method if present
 	if doc.Method != "" {
 		validMethods := map[string]bool{
+			// Standard HTTP methods
 			"GET": true, "POST": true, "PUT": true, "DELETE": true,
 			"HEAD": true, "OPTIONS": true, "PATCH": true, "CONNECT": true, "TRACE": true,
+			// WebDAV methods (RFC 4918)
+			"PROPFIND": true, "PROPPATCH": true, "MKCOL": true,
+			"COPY": true, "MOVE": true, "LOCK": true, "UNLOCK": true,
 		}
 		if !validMethods[doc.Method] {
 			return false

--- a/internal/nginx_log/parser/parser_test.go
+++ b/internal/nginx_log/parser/parser_test.go
@@ -80,6 +80,37 @@ func TestParser_ParseLine(t *testing.T) {
 					entry.BytesSent == 0
 			},
 		},
+		{
+			name: "WebDAV PROPFIND method",
+			line: `192.168.1.100 - - [25/Dec/2023:10:00:00 +0000] "PROPFIND /webdav/ HTTP/1.1" 207 1234 "-" "davfs2/1.5.4"`,
+			validate: func(entry *AccessLogEntry) bool {
+				return entry.IP == "192.168.1.100" &&
+					entry.Method == "PROPFIND" &&
+					entry.Path == "/webdav/" &&
+					entry.Status == 207 &&
+					entry.BytesSent == 1234
+			},
+		},
+		{
+			name: "WebDAV MKCOL method",
+			line: `10.0.0.5 - - [25/Dec/2023:10:00:00 +0000] "MKCOL /webdav/newdir/ HTTP/1.1" 201 0 "-" "WebDAVClient/1.0"`,
+			validate: func(entry *AccessLogEntry) bool {
+				return entry.IP == "10.0.0.5" &&
+					entry.Method == "MKCOL" &&
+					entry.Path == "/webdav/newdir/" &&
+					entry.Status == 201
+			},
+		},
+		{
+			name: "WebDAV LOCK method",
+			line: `172.16.0.1 - - [25/Dec/2023:10:00:00 +0000] "LOCK /webdav/file.txt HTTP/1.1" 200 512 "-" "Microsoft-WebDAV"`,
+			validate: func(entry *AccessLogEntry) bool {
+				return entry.IP == "172.16.0.1" &&
+					entry.Method == "LOCK" &&
+					entry.Path == "/webdav/file.txt" &&
+					entry.Status == 200
+			},
+		},
 	}
 
 	config := DefaultParserConfig()

--- a/internal/nginx_log/parser/types.go
+++ b/internal/nginx_log/parser/types.go
@@ -100,8 +100,9 @@ func DefaultParserConfig() *Config {
 	}
 }
 
-// ValidHTTPMethods Valid HTTP methods
+// ValidHTTPMethods Valid HTTP methods including WebDAV methods
 var ValidHTTPMethods = map[string]bool{
+	// Standard HTTP methods
 	"GET":     true,
 	"POST":    true,
 	"PUT":     true,
@@ -111,6 +112,14 @@ var ValidHTTPMethods = map[string]bool{
 	"PATCH":   true,
 	"TRACE":   true,
 	"CONNECT": true,
+	// WebDAV methods (RFC 4918)
+	"PROPFIND":  true,
+	"PROPPATCH": true,
+	"MKCOL":     true,
+	"COPY":      true,
+	"MOVE":      true,
+	"LOCK":      true,
+	"UNLOCK":    true,
 }
 
 // Parser errors (moved to errors.go as Cosy Errors)


### PR DESCRIPTION
Add WebDAV HTTP methods to the Nginx log parser and indexer to correctly process WebDAV requests.

Previously, WebDAV methods like `PROPFIND` were not recognized by the log parser, leading to these requests being dropped or having an empty method field in structured logs. This PR updates the `ValidHTTPMethods` map and the indexer's validation logic to include common WebDAV methods and adds corresponding test cases.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-16073230-57fe-4ed8-8b83-9cd7f2100808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-16073230-57fe-4ed8-8b83-9cd7f2100808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change to method allowlists plus tests; risk is limited to slightly broader acceptance of log entries during parsing/indexing.
> 
> **Overview**
> Extends HTTP method handling to recognize common WebDAV verbs (e.g., `PROPFIND`, `MKCOL`, `LOCK`, `COPY`, `MOVE`, `UNLOCK`) so these requests populate `method` during parsing and pass index-time validation.
> 
> Adds parser test coverage for WebDAV request lines to ensure these methods are extracted correctly (including expected status/bytes fields).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36ef12843e2ea2863cfea87a29b0c2a8f3f10e05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->