### PR TITLE
Nginx-UI disk I/O

### DIFF
--- a/internal/cache/index.go
+++ b/internal/cache/index.go
@@ -368,14 +368,10 @@ func isConfigFilePath(filePath string) bool {
 	// are typically config files. Use separator-bounded matching to avoid false positives
 	// like "myconf.db" matching "conf.d" across the name/extension boundary
 	for _, pattern := range configDirPatterns {
-		// Check if pattern appears in the middle of path (with slashes on both sides)
+		// Check if pattern appears in the path (with slashes on both sides)
+		// This covers both middle-of-path and start-of-path cases since relativePath
+		// always starts with a separator after TrimPrefix from a Clean'd configRoot
 		if strings.Contains(lowerRelativePath, sep+pattern+sep) {
-			return true
-		}
-		// Check if path starts with this directory name (after config root)
-		// Note: We only check pattern+sep here because sep+pattern+sep is already covered
-		// by the Contains check above (if a string starts with X, it contains X)
-		if strings.HasPrefix(lowerRelativePath, pattern+sep) {
 			return true
 		}
 	}


### PR DESCRIPTION
Filter file watcher and scanner to ignore static asset directories and non-config files to prevent disk I/O overload.

When static asset folders (like `/etc/nginx/html/dist`) were placed in the nginx config path, the file monitoring system (fsnotify) would generate a huge number of events for every file change (e.g., during zip extraction). Each event triggered a file scan, leading to massive I/O operations and server unresponsiveness. This PR introduces granular filtering for both directories and individual files to ensure only relevant Nginx configuration files are processed.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-f3591099-69e7-46ca-ac63-12228913e59b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f3591099-69e7-46ca-ac63-12228913e59b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core file-watching and scan inclusion logic; misclassification could cause some valid configs to be missed or delay index updates, though impact is limited to scanning behavior.
> 
> **Overview**
> Reduces disk I/O from the nginx config scanner/watcher by **filtering out static-asset directories and non-config files** so mass file operations (e.g., extracting a zip) don’t trigger scans.
> 
> Expands excluded paths to include common web roots (e.g., `html`, `static`, `assets`, `public`, `webroot`), tightens `shouldSkipPath` to avoid prefix false positives, and introduces `shouldWatchDirectory` + `isConfigFilePath` heuristics (directory-name patterns, nginx config dirs, known config filenames, and a denylist of non-config extensions). These filters are applied to directory walking, dynamic watcher additions, file-event handling (including removals), and recursive scanning to skip irrelevant paths early.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit deb0ad7590ada9d9046d0a1eb8f91b76da1bdcdf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->