### PR TITLE
Docker API stat path

### DIFF
--- a/internal/docker/stat_path.go
+++ b/internal/docker/stat_path.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/0xJacky/Nginx-UI/settings"
+	"github.com/docker/docker/client"
 	"github.com/uozi-tech/cosy/logger"
 )
 
@@ -13,15 +14,45 @@ func StatPath(path string) bool {
 		return false
 	}
 
+	containerName := settings.NginxSettings.ContainerName
 	cli, err := initClient()
 	if err != nil {
+		logger.Error("Failed to initialize Docker client", "error", err)
 		return false
 	}
 	defer cli.Close()
 
-	_, err = cli.ContainerStatPath(context.Background(), settings.NginxSettings.ContainerName, path)
+	ctx := context.Background()
+
+	// First, verify the container exists and is accessible
+	containerInfo, err := cli.ContainerInspect(ctx, containerName)
 	if err != nil {
-		logger.Error("Failed to stat path", "error", err)
+		if client.IsErrNotFound(err) {
+			logger.Error("Container not found. Please verify the container name matches exactly.",
+				"containerName", containerName,
+				"hint", "Check if the container is running with 'docker ps' and verify the NGINX_UI_NGINX_CONTAINER_NAME setting")
+		} else {
+			logger.Error("Failed to inspect container",
+				"containerName", containerName,
+				"error", err)
+		}
+		return false
+	}
+
+	// Log container status for debugging
+	if !containerInfo.State.Running {
+		logger.Warn("Container is not running",
+			"containerName", containerName,
+			"containerState", containerInfo.State.Status)
+	}
+
+	_, err = cli.ContainerStatPath(ctx, containerName, path)
+	if err != nil {
+		logger.Error("Failed to stat path in container",
+			"containerName", containerName,
+			"path", path,
+			"containerRunning", containerInfo.State.Running,
+			"error", err)
 		return false
 	}
 


### PR DESCRIPTION
Improve Docker `StatPath` error messages to better diagnose container not found issues.

The previous 404 "API route and version" error was misleading. The Docker API version negotiation was working correctly, but the daemon returned 404 because the specified container was not found or accessible. This change adds pre-checks and detailed logging to help users identify the actual cause, such as an incorrect container name or a non-running container.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-79053a7d-ca28-4056-84ee-c1cd6a837c68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-79053a7d-ca28-4056-84ee-c1cd6a837c68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

