### PR TITLE
fix: reset retry backoff when sync preview loads to show fresh node status

### DIFF
--- a/api/cluster/node.go
+++ b/api/cluster/node.go
@@ -80,6 +80,13 @@ func DeleteNode(c *gin.Context) {
 		}).Destroy()
 }
 
+func RefreshNodeStatus(c *gin.Context) {
+	analytic.ResetRetryBackoff()
+	c.JSON(http.StatusOK, gin.H{
+		"message": "ok",
+	})
+}
+
 func LoadNodeFromSettings(c *gin.Context) {
 	err := settings.ReloadCluster()
 	if err != nil {

--- a/api/cluster/router.go
+++ b/api/cluster/router.go
@@ -14,6 +14,7 @@ func InitRouter(r *gin.RouterGroup) {
 		nodeGroup.DELETE("/:id", DeleteNode)
 	}
 
+	r.POST("nodes/refresh_status", RefreshNodeStatus)
 	r.POST("nodes/reload_nginx", ReloadNginx)
 	r.POST("nodes/restart_nginx", RestartNginx)
 

--- a/app/src/api/node.ts
+++ b/app/src/api/node.ts
@@ -71,6 +71,7 @@ function restartNginx(nodeIds: number[]) {
 
 const nodeApi = extendCurdApi(useCurdApi<Node>(baseUrl), {
   load_from_settings: () => http.post(`${baseUrl}/load_from_settings`),
+  refreshStatus: () => http.post(`${baseUrl}/refresh_status`),
   reloadNginx,
   restartNginx,
 })

--- a/app/src/components/SyncNodesPreview/SyncNodesPreview.vue
+++ b/app/src/components/SyncNodesPreview/SyncNodesPreview.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Namespace } from '@/api/namespace'
 import namespace from '@/api/namespace'
+import nodeApi from '@/api/node'
 import NodeCard from '@/components/NodeCard'
 
 const props = defineProps<{
@@ -35,6 +36,14 @@ const allSyncNodeIds = computed(() => {
   // Merge and deduplicate
   const allNodes = [...new Set([...namespaceNodes, ...manualNodes])]
   return allNodes
+})
+
+// When sync nodes become visible, reset the backend retry backoff so that
+// nodes stuck in backoff are re-checked immediately and their status is fresh.
+watch(allSyncNodeIds, newIds => {
+  if (newIds.length > 0) {
+    nodeApi.refreshStatus()
+  }
 })
 </script>
 

--- a/internal/analytic/node_record.go
+++ b/internal/analytic/node_record.go
@@ -130,6 +130,21 @@ func markConnectionSuccess(nodeID uint64) {
 	updateNodeStatus(nodeID, true, "connection_success")
 }
 
+// ResetRetryBackoff resets the retry backoff timers for all nodes,
+// allowing immediate re-checks on the next tick. This is lighter than
+// RestartRetrieveNodesStatus because it does not restart the manager
+// goroutines; it only clears the backoff so existing goroutines will
+// retry on their next 1-second tick.
+func ResetRetryBackoff() {
+	retryMutex.Lock()
+	defer retryMutex.Unlock()
+
+	now := time.Now()
+	for _, state := range retryStates {
+		state.NextRetry = now
+	}
+}
+
 func logCurrentNodeStatus(prefix string) {
 	nodeMapMu.Lock()
 	defer nodeMapMu.Unlock()


### PR DESCRIPTION
## Summary

Fixes #1594 — nodes stuck in retry backoff appear offline in the sync preview even when they are actually online.

**Root cause:** When the sync preview loads, it reads node status from the in-memory `NodeMap` cache. Nodes that previously failed health checks are in exponential backoff (up to 30s intervals), so they are not re-checked promptly. The stale "offline" status is served to the frontend until the backoff timer expires.

**Fix:**
- Add a lightweight `ResetRetryBackoff()` function in `internal/analytic/node_record.go` that resets the `NextRetry` timer for all nodes without restarting the entire node record manager goroutines
- Expose it via a new `POST /api/nodes/refresh_status` endpoint
- Call this endpoint from the `SyncNodesPreview` component when sync node IDs become visible
- The existing per-node goroutines re-check on their next 1-second tick, updating the status within seconds

This is intentionally lighter than the existing `RestartRetrieveNodesStatus()` (used by Add/Edit/Delete node) — it avoids tearing down and recreating all monitoring goroutines and WebSocket connections, only clearing the backoff timers.

## Changed files

| File | Change |
|------|--------|
| `internal/analytic/node_record.go` | Add `ResetRetryBackoff()` function |
| `api/cluster/node.go` | Add `RefreshNodeStatus` handler |
| `api/cluster/router.go` | Register `POST nodes/refresh_status` route |
| `app/src/api/node.ts` | Add `refreshStatus` API method |
| `app/src/components/SyncNodesPreview/SyncNodesPreview.vue` | Call `refreshStatus` when sync nodes become visible |

## Test plan

- [ ] Open a site/stream config page with sync nodes configured
- [ ] Simulate a node temporarily being unreachable (so it enters backoff)
- [ ] Open the sync preview — nodes should refresh to correct status within ~1-2 seconds
- [ ] Verify that Save still works correctly as before
- [ ] Verify that add/edit/delete node operations still restart the full manager as before