### PR TITLE
Add Codex CLI plugin manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "nginx-ui",
+  "version": "0.1.0",
+  "description": "Yet another WebUI for Nginx",
+  "author": {
+    "name": "0xJacky",
+    "url": "https://github.com/0xJacky"
+  },
+  "homepage": "https://github.com/0xJacky/nginx-ui",
+  "repository": "https://github.com/0xJacky/nginx-ui",
+  "keywords": [
+    "mcp",
+    "codex"
+  ],
+  "mcpServers": "./.mcp.json"
+}

--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -1,0 +1,26 @@
+name: Codex Plugin Quality Gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: codex-plugin-scanner-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Codex plugin scanner
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@e83708a91ae4812872aa2905b99ad559a55c74ab
+        with:
+          plugin_dir: "."
+          mode: scan
+          fail_on_severity: critical

--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Codex plugin scanner
-        uses: hashgraph-online/hol-codex-plugin-scanner-action@e83708a91ae4812872aa2905b99ad559a55c74ab
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@0f78e6d99032ec198d23a41a8425080a658c07d1
         with:
           plugin_dir: "."
           mode: scan

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "nginx-ui": {
+      "command": "npx",
+      "args": [
+        "0xJacky-nginx-ui"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This adds a small metadata pass so the repo is easier to wire into Codex without touching runtime code.

I targeted this repo because it already exposes:
- Online statistics for server indicators such as CPU usage, memory usage, load average, and disk usage
- Cluster management supporting mirroring operations to multiple nodes, making multi-server environments easy to manage

It adds `.codex-plugin/plugin.json`, a starter `.mcp.json`, and the scanner workflow.
Permissions: read-only. No secrets. No publish. No runtime changes.
If you want different command wiring or metadata values, I can adjust the branch.