### PR TITLE
fix(app): embed generated assets with underscore names

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-//go:embed dist i18n.json src/language
+//go:embed all:dist i18n.json src/language
 var embeddedFS embed.FS
 
 // GetDistFS returns the embedded filesystem with frontend assets


### PR DESCRIPTION
## Summary

Fixes blank embedded builds by ensuring Vite-generated frontend chunks with leading underscores are included in the Go binary.

**Ref:** https://github.com/0xJacky/nginx-ui/issues/1638#issuecomment-4269684775 | **Fixes #1638**

## Details

Recent Vite builds can emit a helper chunk named like `_plugin-vue_export-helper-*.js` (see: [#1638 ](https://github.com/0xJacky/nginx-ui/issues/1638#issuecomment-4269684775))
The generated `dist/index.html` references that file correctly, and the file is present in `app/dist/assets` after `pnpm build`.

The issue is in the embedded packaging step.
Go's `//go:embed dist ...` pattern embeds directory contents but skips files whose names start with `_` or `.`.
As a result, the helper chunk exists in the frontend build output but is missing from the embedded binary, causing the app to load an `index.html` that references an unavailable asset.

This updates the embed directive to use `all:dist`, so the embedded build includes the frontend `dist` output exactly as generated.

## Verification

- `pnpm --filter nginx-ui-app-next build`
- `go list -json ./app` includes `_plugin-vue_export-helper-*.js`
- `go list -json ./app` still includes regular frontend assets
- `go build -trimpath -tags=jsoniter ...`