### PR TITLE
fix: resolve concurrent map iteration and map write crash in sitecheck

### DIFF
--- a/internal/site/index.go
+++ b/internal/site/index.go
@@ -37,6 +37,19 @@ func GetIndexedSite(path string) *Index {
 	return &Index{}
 }
 
+// GetAllIndexedSites returns a snapshot copy of all indexed sites.
+// This is safe for concurrent access as it holds the read lock while copying.
+func GetAllIndexedSites() map[string]*Index {
+	siteIndexMutex.RLock()
+	defer siteIndexMutex.RUnlock()
+
+	result := make(map[string]*Index, len(IndexedSites))
+	for k, v := range IndexedSites {
+		result[k] = v
+	}
+	return result
+}
+
 func init() {
 	cache.RegisterCallback("site.scanForSite", scanForSite)
 }

--- a/internal/sitecheck/checker.go
+++ b/internal/sitecheck/checker.go
@@ -82,11 +82,14 @@ func (sc *SiteChecker) CollectSites() {
 	// Clear existing sites
 	sc.sites = make(map[string]*SiteInfo)
 
+	// Get a thread-safe snapshot of indexed sites to avoid concurrent map access
+	indexedSites := site.GetAllIndexedSites()
+
 	// Debug: log indexed sites count
-	logger.Debugf("Found %d indexed sites", len(site.IndexedSites))
+	logger.Debugf("Found %d indexed sites", len(indexedSites))
 
 	// Collect URLs from indexed sites, but only from enabled sites
-	for siteName, indexedSite := range site.IndexedSites {
+	for siteName, indexedSite := range indexedSites {
 		// Check site status - only collect from enabled sites
 		siteStatus := site.GetSiteStatus(siteName)
 		if siteStatus != site.StatusEnabled {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixed fatal error `concurrent map iteration and map write` that caused nginx-ui nodes to crash and become unresponsive.

## Problem

The issue occurred in the `sitecheck` package when `CollectSites()` method iterated over `site.IndexedSites` (line 89 in checker.go) while the cache scanner's `scanForSite()` was concurrently modifying the same map. This race condition caused sporadic crashes with the following stack trace:

```
fatal error: concurrent map iteration and map write
goroutine 23 [running]:
internal/runtime/maps.fatal({0x606ed02?, 0x48c6c5?})
        runtime/panic.go:1181 +0x18
internal/runtime/maps.(*Iter).Next(0x4c8301?)
        internal/runtime/maps/table.go:819 +0x86
github.com/0xJacky/Nginx-UI/internal/sitecheck.(*SiteChecker).CollectSites(0x796be5945b0)
        github.com/0xJacky/Nginx-UI/internal/sitecheck/checker.go:89 +0x174
```

## Solution

- Added `GetAllIndexedSites()` function in `internal/site/index.go` that safely returns a snapshot copy of the `IndexedSites` map while holding the read lock
- Modified `CollectSites()` in `internal/sitecheck/checker.go` to use this thread-safe function instead of directly accessing the global map

## Changes

- `internal/site/index.go`: Added new `GetAllIndexedSites()` function for thread-safe access
- `internal/sitecheck/checker.go`: Updated `CollectSites()` to use the new thread-safe function

## Testing

- All existing tests pass
- The fix prevents concurrent map access without changing any behavior

Fixes #1673
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d63d5d6-3e67-404c-9b03-c699b66b1cc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d63d5d6-3e67-404c-9b03-c699b66b1cc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

