### PR TITLE
fix(cert): normalize legacy key types

### DIFF
--- a/api/certificate/certificate.go
+++ b/api/certificate/certificate.go
@@ -11,7 +11,7 @@ import (
 	"github.com/0xJacky/Nginx-UI/model"
 	"github.com/0xJacky/Nginx-UI/query"
 	"github.com/gin-gonic/gin"
-	"github.com/go-acme/lego/v4/certcrypto"
+	"github.com/go-acme/lego/v5/certcrypto"
 	"github.com/spf13/cast"
 	"github.com/uozi-tech/cosy"
 	"github.com/uozi-tech/cosy/logger"
@@ -88,6 +88,23 @@ func GetCert(c *gin.Context) {
 	c.JSON(http.StatusOK, Transformer(certModel))
 }
 
+func normalizeCertKeyType(ctx *cosy.Ctx[model.Cert]) {
+	payloadKeyType := cast.ToString(ctx.Payload["key_type"])
+	if payloadKeyType != "" {
+		ctx.Model.KeyType = helper.GetKeyType(certcrypto.KeyType(payloadKeyType))
+	}
+
+	sslCertificate := cast.ToString(ctx.Payload["ssl_certificate"])
+	if sslCertificate == "" {
+		return
+	}
+
+	keyType, err := cert.GetKeyType(sslCertificate)
+	if err == nil && keyType != "" {
+		ctx.Model.KeyType = helper.GetKeyType(certcrypto.KeyType(keyType))
+	}
+}
+
 func AddCert(c *gin.Context) {
 	cosy.Core[model.Cert](c).
 		SetValidRules(gin.H{
@@ -106,26 +123,7 @@ func AddCert(c *gin.Context) {
 			"revoke_old":                 "omitempty",
 		}).
 		BeforeExecuteHook(func(ctx *cosy.Ctx[model.Cert]) {
-			sslCertificate := cast.ToString(ctx.Payload["ssl_certificate"])
-			// Detect and set certificate type
-			if sslCertificate != "" {
-				keyType, err := cert.GetKeyType(sslCertificate)
-				if err == nil && keyType != "" {
-					// Set KeyType based on certificate type
-					switch keyType {
-					case "2048":
-						ctx.Model.KeyType = certcrypto.RSA2048
-					case "3072":
-						ctx.Model.KeyType = certcrypto.RSA3072
-					case "4096":
-						ctx.Model.KeyType = certcrypto.RSA4096
-					case "P256":
-						ctx.Model.KeyType = certcrypto.EC256
-					case "P384":
-						ctx.Model.KeyType = certcrypto.EC384
-					}
-				}
-			}
+			normalizeCertKeyType(ctx)
 		}).
 		ExecutedHook(func(ctx *cosy.Ctx[model.Cert]) {
 			sslCertificate := cast.ToString(ctx.Payload["ssl_certificate"])
@@ -172,26 +170,7 @@ func ModifyCert(c *gin.Context) {
 			"revoke_old":                 "omitempty",
 		}).
 		BeforeExecuteHook(func(ctx *cosy.Ctx[model.Cert]) {
-			sslCertificate := cast.ToString(ctx.Payload["ssl_certificate"])
-			// Detect and set certificate type
-			if sslCertificate != "" {
-				keyType, err := cert.GetKeyType(sslCertificate)
-				if err == nil && keyType != "" {
-					// Set KeyType based on certificate type
-					switch keyType {
-					case "2048":
-						ctx.Model.KeyType = certcrypto.RSA2048
-					case "3072":
-						ctx.Model.KeyType = certcrypto.RSA3072
-					case "4096":
-						ctx.Model.KeyType = certcrypto.RSA4096
-					case "P256":
-						ctx.Model.KeyType = certcrypto.EC256
-					case "P384":
-						ctx.Model.KeyType = certcrypto.EC384
-					}
-				}
-			}
+			normalizeCertKeyType(ctx)
 		}).
 		ExecutedHook(func(ctx *cosy.Ctx[model.Cert]) {
 			sslCertificate := cast.ToString(ctx.Payload["ssl_certificate"])
@@ -228,18 +207,23 @@ func SyncCertificate(c *gin.Context) {
 	if !cosy.BindAndValid(c, &json) {
 		return
 	}
+	normalizedKeyType := helper.GetKeyType(json.KeyType)
 
 	certModel := &model.Cert{
 		Name:                  json.Name,
 		SSLCertificatePath:    json.SSLCertificatePath,
 		SSLCertificateKeyPath: json.SSLCertificateKeyPath,
-		KeyType:               json.KeyType,
+		KeyType:               normalizedKeyType,
 		AutoCert:              model.AutoCertSync,
 	}
 
 	db := model.UseDB()
 
-	err := db.Where(certModel).FirstOrCreate(certModel).Error
+	err := db.Where("name = ? AND ssl_certificate_path = ? AND ssl_certificate_key_path = ? AND key_type IN ?",
+		json.Name, json.SSLCertificatePath, json.SSLCertificateKeyPath,
+		helper.GetKeyTypeAliasStrings(normalizedKeyType)).
+		Assign(&model.Cert{KeyType: normalizedKeyType}).
+		FirstOrCreate(certModel).Error
 	if err != nil {
 		cosy.ErrHandler(c, err)
 		return

--- a/api/certificate/issue.go
+++ b/api/certificate/issue.go
@@ -8,7 +8,7 @@ import (
 	"github.com/0xJacky/Nginx-UI/model"
 	"github.com/0xJacky/Nginx-UI/query"
 	"github.com/gin-gonic/gin"
-	"github.com/go-acme/lego/v4/certcrypto"
+	"github.com/go-acme/lego/v5/certcrypto"
 	"github.com/gorilla/websocket"
 	"github.com/uozi-tech/cosy/logger"
 	"gorm.io/gen/field"
@@ -53,6 +53,7 @@ func IssueCert(c *gin.Context) {
 		logger.Error(err)
 		return
 	}
+	payload.KeyType = payload.GetKeyType()
 
 	certModel, err := model.FirstOrInit(name, payload.GetKeyType())
 	if err != nil {
@@ -87,8 +88,10 @@ func IssueCert(c *gin.Context) {
 
 	cert := query.Cert
 
-	_, err = cert.Where(cert.Name.Eq(name), cert.Filename.Eq(name), cert.KeyType.Eq(string(payload.KeyType))).
+	_, err = cert.Where(cert.Name.Eq(name), cert.Filename.Eq(name),
+		cert.KeyType.In(helper.GetKeyTypeAliasStrings(payload.KeyType)...)).
 		Assign(field.Attrs(&model.Cert{
+			KeyType:                 payload.KeyType,
 			Domains:                 payload.ServerName,
 			SSLCertificatePath:      payload.GetCertificatePath(),
 			SSLCertificateKeyPath:   payload.GetCertificateKeyPath(),

--- a/api/sites/auto_cert.go
+++ b/api/sites/auto_cert.go
@@ -6,7 +6,7 @@ import (
 	"github.com/0xJacky/Nginx-UI/internal/helper"
 	"github.com/0xJacky/Nginx-UI/model"
 	"github.com/gin-gonic/gin"
-	"github.com/go-acme/lego/v4/certcrypto"
+	"github.com/go-acme/lego/v5/certcrypto"
 	"github.com/uozi-tech/cosy"
 )
 
@@ -38,6 +38,7 @@ func AddDomainToAutoCert(c *gin.Context) {
 		AutoCert:        model.AutoCertEnabled,
 		DnsCredentialID: json.DnsCredentialID,
 		ChallengeMethod: json.ChallengeMethod,
+		KeyType:         helper.GetKeyType(json.KeyType),
 		ACMEUserID:      json.ACMEUserID,
 	})
 

--- a/internal/cert/helper.go
+++ b/internal/cert/helper.go
@@ -83,7 +83,7 @@ func IsPrivateKeyPath(path string) bool {
 }
 
 // GetKeyType determines the key type from a PEM certificate string.
-// Returns "2048", "3072", "4096", "P256", "P384" or empty string.
+// Returns "2048", "3072", "4096", "8192", "P256", "P384" or empty string.
 func GetKeyType(pemStr string) (string, error) {
 	block, _ := pem.Decode([]byte(pemStr))
 	if block == nil {
@@ -109,6 +109,8 @@ func GetKeyType(pemStr string) (string, error) {
 			return "3072", nil
 		case 4096:
 			return "4096", nil
+		case 8192:
+			return "8192", nil
 		default:
 			return "", nil
 		}
@@ -132,7 +134,7 @@ func GetKeyType(pemStr string) (string, error) {
 }
 
 // GetKeyTypeFromPath determines the key type from a certificate file.
-// Returns "2048", "3072", "4096", "P256", "P384" or empty string.
+// Returns "2048", "3072", "4096", "8192", "P256", "P384" or empty string.
 func GetKeyTypeFromPath(path string) (string, error) {
 	if path == "" {
 		return "", ErrCertPathIsEmpty

--- a/internal/cert/issue.go
+++ b/internal/cert/issue.go
@@ -1,7 +1,7 @@
 package cert
 
 import (
-	"log"
+	"log/slog"
 	"os"
 	"runtime"
 	"time"
@@ -13,11 +13,11 @@ import (
 	"github.com/0xJacky/Nginx-UI/model"
 	"github.com/0xJacky/Nginx-UI/query"
 	"github.com/0xJacky/Nginx-UI/settings"
-	"github.com/go-acme/lego/v4/challenge/dns01"
-	"github.com/go-acme/lego/v4/challenge/http01"
-	"github.com/go-acme/lego/v4/lego"
-	legolog "github.com/go-acme/lego/v4/log"
-	dnsproviders "github.com/go-acme/lego/v4/providers/dns"
+	"github.com/go-acme/lego/v5/challenge/dns01"
+	"github.com/go-acme/lego/v5/challenge/http01"
+	"github.com/go-acme/lego/v5/lego"
+	legolog "github.com/go-acme/lego/v5/log"
+	dnsproviders "github.com/go-acme/lego/v5/providers/dns"
 	"github.com/uozi-tech/cosy"
 	"github.com/uozi-tech/cosy/logger"
 	cSettings "github.com/uozi-tech/cosy/settings"
@@ -38,20 +38,18 @@ func IssueCert(payload *ConfigPayload, certLogger *Logger) error {
 			logger.Errorf("%s\n%s", err, buf)
 		}
 	}()
+	payload.KeyType = payload.GetKeyType()
 
 	// initial a channelWriter to receive logs
 	cw := NewChannelWriter()
 	defer close(cw.Ch)
 
-	// initial a logger
-	l := log.New(os.Stderr, "", log.LstdFlags)
-	l.SetOutput(cw)
-
 	// Hijack the (logger) of lego
-	legolog.Logger = l
+	oldLogger := legolog.Default()
+	legolog.SetDefault(slog.New(slog.NewTextHandler(cw, nil)))
 	// Restore the original logger, fix #876
 	defer func() {
-		legolog.Logger = log.New(os.Stderr, "", log.LstdFlags)
+		legolog.SetDefault(oldLogger)
 	}()
 
 	certLogger.Info(translation.C("[Nginx UI] Preparing lego configurations"))
@@ -86,8 +84,6 @@ func IssueCert(payload *ConfigPayload, certLogger *Logger) error {
 		}
 		config.HTTPClient.Transport = t
 	}
-
-	config.Certificate.KeyType = payload.GetKeyType()
 
 	certLogger.Info(translation.C("[Nginx UI] Creating client facilitates communication with the CA server"))
 	// A client facilitates communication with the CA server.
@@ -133,15 +129,15 @@ func IssueCert(payload *ConfigPayload, certLogger *Logger) error {
 			if err != nil {
 				return cosy.WrapErrorWithParams(ErrNewDNSChallengeProvider, err.Error())
 			}
-			challengeOptions := make([]dns01.ChallengeOption, 0)
-
 			if len(settings.CertSettings.RecursiveNameservers) > 0 {
-				challengeOptions = append(challengeOptions,
-					dns01.AddRecursiveNameservers(settings.CertSettings.RecursiveNameservers),
-				)
+				oldDNSClient := dns01.DefaultClient()
+				dns01.SetDefaultClient(dns01.NewClient(&dns01.Options{
+					RecursiveNameservers: settings.CertSettings.RecursiveNameservers,
+				}))
+				defer dns01.SetDefaultClient(oldDNSClient)
 			}
 
-			err = client.Challenge.SetDNS01Provider(provider, challengeOptions...)
+			err = client.Challenge.SetDNS01Provider(provider)
 		} else {
 			return ErrEnvironmentConfigurationIsEmpty
 		}

--- a/internal/cert/sync.go
+++ b/internal/cert/sync.go
@@ -13,7 +13,7 @@ import (
 	"github.com/0xJacky/Nginx-UI/internal/transport"
 	"github.com/0xJacky/Nginx-UI/model"
 	"github.com/0xJacky/Nginx-UI/query"
-	"github.com/go-acme/lego/v4/certcrypto"
+	"github.com/go-acme/lego/v5/certcrypto"
 	"github.com/uozi-tech/cosy/logger"
 )
 
@@ -55,7 +55,7 @@ func SyncToRemoteServer(c *model.Cert) (err error) {
 		SSLCertificateKeyPath: c.SSLCertificateKeyPath,
 		SSLCertificate:        string(certBytes),
 		SSLCertificateKey:     string(keyBytes),
-		KeyType:               c.KeyType,
+		KeyType:               c.GetKeyType(),
 	}
 
 	payloadBytes, err := json.Marshal(payload)

--- a/internal/helper/key_type.go
+++ b/internal/helper/key_type.go
@@ -1,12 +1,75 @@
 package helper
 
-import "github.com/go-acme/lego/v4/certcrypto"
+import "github.com/go-acme/lego/v5/certcrypto"
+
+const (
+	legacyEC256   certcrypto.KeyType = "P256"
+	legacyEC384   certcrypto.KeyType = "P384"
+	legacyRSA2048 certcrypto.KeyType = "2048"
+	legacyRSA3072 certcrypto.KeyType = "3072"
+	legacyRSA4096 certcrypto.KeyType = "4096"
+	legacyRSA8192 certcrypto.KeyType = "8192"
+)
 
 func GetKeyType(keyType certcrypto.KeyType) certcrypto.KeyType {
 	switch keyType {
 	case certcrypto.RSA2048, certcrypto.RSA3072, certcrypto.RSA4096, certcrypto.RSA8192,
 		certcrypto.EC256, certcrypto.EC384:
 		return keyType
+	case legacyEC256:
+		return certcrypto.EC256
+	case legacyEC384:
+		return certcrypto.EC384
+	case legacyRSA2048:
+		return certcrypto.RSA2048
+	case legacyRSA3072:
+		return certcrypto.RSA3072
+	case legacyRSA4096:
+		return certcrypto.RSA4096
+	case legacyRSA8192:
+		return certcrypto.RSA8192
 	}
 	return certcrypto.RSA2048
+}
+
+func GetKeyTypeAliases(keyType certcrypto.KeyType) []certcrypto.KeyType {
+	normalizedKeyType := GetKeyType(keyType)
+
+	switch normalizedKeyType {
+	case certcrypto.EC256:
+		return []certcrypto.KeyType{certcrypto.EC256, legacyEC256}
+	case certcrypto.EC384:
+		return []certcrypto.KeyType{certcrypto.EC384, legacyEC384}
+	case certcrypto.RSA2048:
+		return []certcrypto.KeyType{certcrypto.RSA2048, legacyRSA2048}
+	case certcrypto.RSA3072:
+		return []certcrypto.KeyType{certcrypto.RSA3072, legacyRSA3072}
+	case certcrypto.RSA4096:
+		return []certcrypto.KeyType{certcrypto.RSA4096, legacyRSA4096}
+	case certcrypto.RSA8192:
+		return []certcrypto.KeyType{certcrypto.RSA8192, legacyRSA8192}
+	}
+
+	return []certcrypto.KeyType{normalizedKeyType}
+}
+
+func GetKeyTypeAliasStrings(keyType certcrypto.KeyType) []string {
+	aliases := GetKeyTypeAliases(keyType)
+	values := make([]string, 0, len(aliases))
+
+	for _, alias := range aliases {
+		values = append(values, string(alias))
+	}
+
+	return values
+}
+
+func IsValidKeyType(keyType certcrypto.KeyType) bool {
+	switch keyType {
+	case "", certcrypto.RSA2048, certcrypto.RSA3072, certcrypto.RSA4096, certcrypto.RSA8192,
+		certcrypto.EC256, certcrypto.EC384, legacyEC256, legacyEC384,
+		legacyRSA2048, legacyRSA3072, legacyRSA4096, legacyRSA8192:
+		return true
+	}
+	return false
 }

--- a/internal/helper/key_type_test.go
+++ b/internal/helper/key_type_test.go
@@ -1,0 +1,39 @@
+package helper
+
+import (
+	"testing"
+
+	"github.com/go-acme/lego/v5/certcrypto"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetKeyTypeSupportsLegacyLegoV4Values(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    certcrypto.KeyType
+		expected certcrypto.KeyType
+	}{
+		{name: "EC256", input: "P256", expected: certcrypto.EC256},
+		{name: "EC384", input: "P384", expected: certcrypto.EC384},
+		{name: "RSA2048", input: "2048", expected: certcrypto.RSA2048},
+		{name: "RSA3072", input: "3072", expected: certcrypto.RSA3072},
+		{name: "RSA4096", input: "4096", expected: certcrypto.RSA4096},
+		{name: "RSA8192", input: "8192", expected: certcrypto.RSA8192},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, GetKeyType(tt.input))
+			assert.True(t, IsValidKeyType(tt.input))
+		})
+	}
+}
+
+func TestGetKeyTypeAliasesIncludesLegacyAndCurrentValues(t *testing.T) {
+	assert.ElementsMatch(t, []certcrypto.KeyType{certcrypto.EC256, "P256"}, GetKeyTypeAliases(certcrypto.EC256))
+	assert.ElementsMatch(t, []certcrypto.KeyType{certcrypto.EC384, "P384"}, GetKeyTypeAliases("P384"))
+	assert.ElementsMatch(t, []certcrypto.KeyType{certcrypto.RSA2048, "2048"}, GetKeyTypeAliases(certcrypto.RSA2048))
+	assert.ElementsMatch(t, []certcrypto.KeyType{certcrypto.RSA3072, "3072"}, GetKeyTypeAliases("3072"))
+	assert.ElementsMatch(t, []certcrypto.KeyType{certcrypto.RSA4096, "4096"}, GetKeyTypeAliases(certcrypto.RSA4096))
+	assert.ElementsMatch(t, []certcrypto.KeyType{certcrypto.RSA8192, "8192"}, GetKeyTypeAliases("8192"))
+}

--- a/internal/validation/key_type.go
+++ b/internal/validation/key_type.go
@@ -1,15 +1,11 @@
 package validation
 
 import (
-	"github.com/go-acme/lego/v4/certcrypto"
+	"github.com/0xJacky/Nginx-UI/internal/helper"
+	"github.com/go-acme/lego/v5/certcrypto"
 	val "github.com/go-playground/validator/v10"
 )
 
 func autoCertKeyType(fl val.FieldLevel) bool {
-	switch certcrypto.KeyType(fl.Field().String()) {
-	case "", certcrypto.RSA2048, certcrypto.RSA3072, certcrypto.RSA4096, certcrypto.RSA8192,
-		certcrypto.EC256, certcrypto.EC384:
-		return true
-	}
-	return false
+	return helper.IsValidKeyType(certcrypto.KeyType(fl.Field().String()))
 }

--- a/model/cert.go
+++ b/model/cert.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/0xJacky/Nginx-UI/internal/helper"
 	"github.com/0xJacky/Nginx-UI/internal/nginx"
-	"github.com/go-acme/lego/v4/certcrypto"
-	"github.com/go-acme/lego/v4/certificate"
+	"github.com/go-acme/lego/v5/certcrypto"
+	"github.com/go-acme/lego/v5/certificate"
 	"gorm.io/gorm/clause"
 )
 
@@ -23,6 +23,7 @@ type CertDomains []string
 
 type CertificateResource struct {
 	*certificate.Resource
+	Domain            string `json:"domain,omitempty"`
 	PrivateKey        []byte `json:"private_key"`
 	Certificate       []byte `json:"certificate"`
 	IssuerCertificate []byte `json:"issuerCertificate"`
@@ -62,13 +63,22 @@ func FirstCert(confName string) (c Cert, err error) {
 }
 
 func FirstOrCreateCert(confName string, keyType certcrypto.KeyType) (c Cert, err error) {
+	normalizedKeyType := helper.GetKeyType(keyType)
+
 	// Filename is used to check whether this site is enabled
-	err = db.FirstOrCreate(&c, &Cert{Name: confName, Filename: confName, KeyType: keyType}).Error
+	err = db.Where("name = ? AND filename = ? AND key_type IN ?", confName, confName,
+		helper.GetKeyTypeAliasStrings(normalizedKeyType)).
+		Assign(&Cert{KeyType: normalizedKeyType}).
+		FirstOrCreate(&c, &Cert{Name: confName, Filename: confName, KeyType: normalizedKeyType}).Error
 	return
 }
 
 func FirstOrInit(confName string, keyType certcrypto.KeyType) (c Cert, err error) {
-	err = db.FirstOrInit(&c, &Cert{Name: confName, Filename: confName, KeyType: keyType}).Error
+	normalizedKeyType := helper.GetKeyType(keyType)
+	err = db.Where("name = ? AND filename = ? AND key_type IN ?", confName, confName,
+		helper.GetKeyTypeAliasStrings(normalizedKeyType)).
+		FirstOrInit(&c, &Cert{Name: confName, Filename: confName, KeyType: normalizedKeyType}).Error
+	c.KeyType = normalizedKeyType
 	return
 }
 
@@ -122,8 +132,17 @@ func (c *Cert) GetKeyType() certcrypto.KeyType {
 }
 
 func (c *CertificateResource) GetResource() certificate.Resource {
+	domains := c.Resource.Domains
+	if len(domains) == 0 && c.Domain != "" {
+		domains = []string{c.Domain}
+	}
+
 	return certificate.Resource{
-		Domain:            c.Resource.Domain,
+		ID:                c.Resource.ID,
+		Domains:           domains,
+		KeyType:           c.Resource.KeyType,
+		PreferredChain:    c.Resource.PreferredChain,
+		Profile:           c.Resource.Profile,
 		CertURL:           c.Resource.CertURL,
 		CertStableURL:     c.Resource.CertStableURL,
 		PrivateKey:        c.PrivateKey,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches certificate issuance/sync and DB upsert logic while upgrading `go-acme/lego` to v5; mistakes could cause duplicate cert records or wrong key type selection during issuance/sync.
> 
> **Overview**
> Upgrades `go-acme/lego` usage from v4 to v5 across certificate APIs and issuance logic, including updating lego log capture and DNS01 recursive nameserver configuration.
> 
> Adds key-type normalization and legacy alias handling (e.g., v4 values like `"P256"`, `"2048"`) via new helpers, applies it when creating/modifying/syncing/issuing certs, and updates DB lookups to match `key_type` across aliases while persisting the normalized value.
> 
> Extends key-type detection to include RSA `8192`, updates `auto_cert_key_type` validation to accept legacy values, and adds unit tests for normalization/alias behavior; also adjusts `CertificateResource` serialization to preserve domain(s) for lego v5 resources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db23a87a45b7259dc1899b9ec9e65d637b5e16ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->