### PR TITLE
fix: normalize DNS provider env values

### DIFF
--- a/internal/cert/dns/config_env.go
+++ b/internal/cert/dns/config_env.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -24,6 +25,7 @@ type Config struct {
 	Code          string         `json:"code"`
 	Configuration *Configuration `json:"configuration,omitempty"`
 	Links         *Links         `json:"links,omitempty"`
+	envBackup     map[string]*string
 }
 
 var configurations []Config
@@ -86,16 +88,16 @@ func (c *Config) SetEnv(configuration Configuration) error {
 	if c.Configuration != nil {
 		for k := range c.Configuration.Credentials {
 			if value, ok := configuration.Credentials[k]; ok {
-				err := os.Setenv(k, value)
-				if err != nil {
+				if err := c.setEnv(k, value); err != nil {
+					c.CleanEnv()
 					return err
 				}
 			}
 		}
 		for k := range c.Configuration.Additional {
 			if value, ok := configuration.Additional[k]; ok {
-				err := os.Setenv(k, value)
-				if err != nil {
+				if err := c.setEnv(k, value); err != nil {
+					c.CleanEnv()
 					return err
 				}
 			}
@@ -107,10 +109,71 @@ func (c *Config) SetEnv(configuration Configuration) error {
 func (c *Config) CleanEnv() {
 	if c.Configuration != nil {
 		for k := range c.Configuration.Credentials {
-			_ = os.Unsetenv(k)
+			c.restoreEnv(k)
 		}
 		for k := range c.Configuration.Additional {
-			_ = os.Unsetenv(k)
+			c.restoreEnv(k)
 		}
 	}
+}
+
+func normalizeEnvValue(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if len(trimmed) < 2 {
+		return trimmed
+	}
+
+	first := trimmed[0]
+	last := trimmed[len(trimmed)-1]
+	if first != last || first != '"' && first != '\'' {
+		return trimmed
+	}
+	if first == '\'' {
+		return trimmed[1 : len(trimmed)-1]
+	}
+
+	unquoted, err := strconv.Unquote(trimmed)
+	if err != nil {
+		return trimmed[1 : len(trimmed)-1]
+	}
+
+	return unquoted
+}
+
+func (c *Config) setEnv(key, value string) error {
+	c.backupEnv(key)
+	return os.Setenv(key, normalizeEnvValue(value))
+}
+
+func (c *Config) backupEnv(key string) {
+	if c.envBackup == nil {
+		c.envBackup = make(map[string]*string)
+	}
+	if _, ok := c.envBackup[key]; ok {
+		return
+	}
+
+	value, exists := os.LookupEnv(key)
+	if !exists {
+		c.envBackup[key] = nil
+		return
+	}
+
+	copied := value
+	c.envBackup[key] = &copied
+}
+
+func (c *Config) restoreEnv(key string) {
+	if c.envBackup == nil {
+		_ = os.Unsetenv(key)
+		return
+	}
+
+	value, exists := c.envBackup[key]
+	if !exists || value == nil {
+		_ = os.Unsetenv(key)
+		return
+	}
+
+	_ = os.Setenv(key, *value)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Normalize DNS provider credential values before exporting them to lego environment variables, including trimming pasted whitespace and unwrapping matching shell-style quotes.
- Restore any pre-existing environment variables after certificate issuance instead of unconditionally unsetting them.
- Clean up partially applied environment variables if setting a provider value fails.

## Validation
- `go test ./internal/cert/dns`
- `go test ./internal/cert/dns ./internal/cert` *(fails while loading `internal/cert` because `app/app.go` embeds `app/dist`, which is absent in this workspace; `internal/cert/dns` passes in the same run).*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36bab829-9c6d-4d5f-9e8a-e7f251a5cac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36bab829-9c6d-4d5f-9e8a-e7f251a5cac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

