### PR TITLE
fix: expand TLS includes for maintenance mode

### DIFF
--- a/api/sites/security_test.go
+++ b/api/sites/security_test.go
@@ -91,3 +91,19 @@ func TestSiteSaveRequiresSecureSessionForOTPUser(t *testing.T) {
 		t.Fatalf("expected 401, got %d", recorder.Code)
 	}
 }
+
+func TestEnableMaintenanceSiteRejectsInvalidSiteName(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Params = gin.Params{{Key: "name", Value: "..%2F..%2Fnginx.conf"}}
+
+	EnableMaintenanceSite(c)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d with body %q", recorder.Code, recorder.Body.String())
+	}
+	if !bytes.Contains(recorder.Body.Bytes(), []byte("invalid site name")) {
+		t.Fatalf("expected invalid site name response, got %q", recorder.Body.String())
+	}
+}

--- a/api/sites/site.go
+++ b/api/sites/site.go
@@ -397,8 +397,8 @@ func BatchUpdateSites(c *gin.Context) {
 }
 
 func isInvalidSiteName(name string) bool {
-	return name == "" || name == "." || name == ".." ||
-		strings.Contains(name, "/") || strings.Contains(name, "\\") || strings.Contains(name, "..")
+	return name == "" || name == "." ||
+		strings.ContainsAny(name, `/\`) || strings.Contains(name, "..")
 }
 
 func EnableMaintenanceSite(c *gin.Context) {

--- a/api/sites/site.go
+++ b/api/sites/site.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/0xJacky/Nginx-UI/internal/cert"
@@ -395,8 +396,19 @@ func BatchUpdateSites(c *gin.Context) {
 		}).BatchModify()
 }
 
+func isInvalidSiteName(name string) bool {
+	return name == "" || name == "." || name == ".." ||
+		strings.Contains(name, "/") || strings.Contains(name, "\\") || strings.Contains(name, "..")
+}
+
 func EnableMaintenanceSite(c *gin.Context) {
 	name := helper.UnescapeURL(c.Param("name"))
+	if isInvalidSiteName(name) {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "invalid site name",
+		})
+		return
+	}
 
 	// If site is already enabled, disable the normal site first
 	enabledConfigPath, err := site.ResolveEnabledPath(name)

--- a/internal/nginx/build_config.go
+++ b/internal/nginx/build_config.go
@@ -75,6 +75,10 @@ func (c *NgxConfig) BuildConfig() (content string, err error) {
 			if directive.Comments != "" {
 				comments = buildComments(directive.Comments, 1)
 			}
+			if directive.Raw != "" {
+				server += comments + indentRawDirective(directive.Raw, 1) + "\n"
+				continue
+			}
 			if directive.Params != "" {
 				server += fmt.Sprintf("%s\t%s;\n", comments, directive.Orig())
 			}
@@ -121,4 +125,20 @@ func (c *NgxConfig) BuildConfig() (content string, err error) {
 
 	content = dumper.DumpConfig(cfg, dumper.IndentedStyle)
 	return
+}
+
+func indentRawDirective(raw string, indent int) string {
+	indentation := strings.Repeat("\t", indent)
+	var builder strings.Builder
+
+	// Use strings.Split rather than bufio.Scanner: the latter caps a single line
+	// at MaxScanTokenSize (64 KiB) and would silently drop content for very long
+	// embedded blocks (e.g. lua blocks with long single lines).
+	for _, line := range strings.Split(strings.TrimRight(raw, "\n"), "\n") {
+		builder.WriteString(indentation)
+		builder.WriteString(line)
+		builder.WriteByte('\n')
+	}
+
+	return strings.TrimRight(builder.String(), "\n")
 }

--- a/internal/nginx/root_block_test.go
+++ b/internal/nginx/root_block_test.go
@@ -1,9 +1,32 @@
 package nginx
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
+
+func TestNgxDirectiveRawIsInternalOnly(t *testing.T) {
+	data, err := json.Marshal(NgxDirective{
+		Directive: "ssl_certificate_by_lua_block",
+		Params:    "placeholder",
+		Raw:       "ssl_certificate_by_lua_block { auto_ssl:ssl_certificate() }",
+	})
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if strings.Contains(string(data), "raw") || strings.Contains(string(data), "auto_ssl") {
+		t.Fatalf("NgxDirective JSON = %s, want Raw omitted from external representation", data)
+	}
+
+	var directive NgxDirective
+	if err := json.Unmarshal([]byte(`{"directive":"listen","params":"443 ssl","raw":"server_name injected.example.com"}`), &directive); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if directive.Raw != "" {
+		t.Fatalf("Raw = %q, want external JSON input ignored", directive.Raw)
+	}
+}
 
 func TestParseNgxConfigByContent_UnwrapsRootStreamBlock(t *testing.T) {
 	content := `stream {

--- a/internal/nginx/type.go
+++ b/internal/nginx/type.go
@@ -33,6 +33,12 @@ type NgxDirective struct {
 	Directive string `json:"directive"`
 	Params    string `json:"params"`
 	Comments  string `json:"comments"`
+	// Raw, when non-empty, is the verbatim source text of the directive (including
+	// any block body). BuildConfig prefers Raw over Directive/Params so that block
+	// directives (e.g. ssl_certificate_by_lua_block) and quoted parameters survive
+	// a maintenance-config rebuild without being flattened. Keep Directive and
+	// Params populated for callers that consume this struct via JSON.
+	Raw string `json:"-"`
 }
 
 type NgxLocation struct {

--- a/internal/site/maintenance.go
+++ b/internal/site/maintenance.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 
@@ -15,12 +17,39 @@ import (
 	"github.com/0xJacky/Nginx-UI/settings"
 	"github.com/go-resty/resty/v2"
 	"github.com/tufanbarisyildirim/gonginx/config"
+	"github.com/tufanbarisyildirim/gonginx/dumper"
 	"github.com/tufanbarisyildirim/gonginx/parser"
 	"github.com/uozi-tech/cosy/logger"
 	cSettings "github.com/uozi-tech/cosy/settings"
 )
 
 const MaintenanceSuffix = "_nginx_ui_maintenance"
+
+var baseMaintenanceServerDirectives = map[string]struct{}{
+	"listen":      {},
+	"server_name": {},
+	"http2":       {},
+}
+
+const (
+	maintenanceMaxIncludeDepth       = 5
+	maintenanceMaxWildcardMatches    = 32
+	maintenanceIncludeDebugLogPrefix = "maintenance include expansion"
+)
+
+// certbotNginxTLSOptionsPath is the well-known certbot-managed SSL options snippet.
+// It is the only path outside the nginx configuration directory that is allowed
+// to be expanded into the maintenance configuration, because certbot installs it
+// at a fixed location and its contents are known-safe TLS hardening directives.
+// The value is cleaned at init time so OS-specific separators do not break the
+// equality check against `filepath.Clean`-normalized include paths.
+var certbotNginxTLSOptionsPath = filepath.Clean("/etc/letsencrypt/options-ssl-nginx.conf")
+
+type maintenanceIncludeExpander struct {
+	baseDir string
+	confDir string
+	visited map[string]struct{}
+}
 
 // EnableMaintenance enables maintenance mode for a site
 func EnableMaintenance(name string) (err error) {
@@ -62,7 +91,7 @@ func EnableMaintenance(name string) (err error) {
 	}
 
 	// Create new maintenance configuration
-	maintenanceConfig := createMaintenanceConfig(conf)
+	maintenanceConfig := createMaintenanceConfig(conf, filepath.Dir(configFilePath))
 
 	// Write maintenance configuration to file
 	err = os.WriteFile(maintenanceConfigPath, []byte(maintenanceConfig), 0644)
@@ -164,8 +193,10 @@ func DisableMaintenance(name string) (err error) {
 	return nil
 }
 
-// createMaintenanceConfig creates a maintenance configuration based on the original config
-func createMaintenanceConfig(conf *config.Config) string {
+// createMaintenanceConfig creates a maintenance configuration based on the original config.
+// baseDir is the directory used to resolve relative include directives; pass "" to fall back
+// to the nginx configuration directory.
+func createMaintenanceConfig(conf *config.Config, baseDir string) string {
 	nginxUIPort := cSettings.ServerSettings.Port
 	schema := "http"
 	if cSettings.ServerSettings.EnableHTTPS {
@@ -177,57 +208,21 @@ func createMaintenanceConfig(conf *config.Config) string {
 
 	// Find all server blocks in the original configuration
 	serverBlocks := findServerBlocks(conf.Block)
+	includeBaseDir := baseDir
+	if includeBaseDir == "" {
+		includeBaseDir = nginx.GetConfPath()
+	}
 
 	// Create maintenance mode configuration for each server block
 	for _, server := range serverBlocks {
 		ngxServer := nginx.NewNgxServer()
 
-		// Copy listen directives
-		listenDirectives := extractDirectives(server, "listen")
-		for _, directive := range listenDirectives {
+		// Preserve server identity and TLS handshake settings from the original site.
+		for _, directive := range extractMaintenanceServerDirectives(server, includeBaseDir) {
 			ngxDirective := &nginx.NgxDirective{
 				Directive: directive.GetName(),
 				Params:    strings.Join(extractParams(directive), " "),
-			}
-			ngxServer.Directives = append(ngxServer.Directives, ngxDirective)
-		}
-
-		// Copy server_name directives
-		serverNameDirectives := extractDirectives(server, "server_name")
-		for _, directive := range serverNameDirectives {
-			ngxDirective := &nginx.NgxDirective{
-				Directive: directive.GetName(),
-				Params:    strings.Join(extractParams(directive), " "),
-			}
-			ngxServer.Directives = append(ngxServer.Directives, ngxDirective)
-		}
-
-		// Copy SSL certificate directives
-		sslCertDirectives := extractDirectives(server, "ssl_certificate")
-		for _, directive := range sslCertDirectives {
-			ngxDirective := &nginx.NgxDirective{
-				Directive: directive.GetName(),
-				Params:    strings.Join(extractParams(directive), " "),
-			}
-			ngxServer.Directives = append(ngxServer.Directives, ngxDirective)
-		}
-
-		// Copy SSL certificate key directives
-		sslKeyDirectives := extractDirectives(server, "ssl_certificate_key")
-		for _, directive := range sslKeyDirectives {
-			ngxDirective := &nginx.NgxDirective{
-				Directive: directive.GetName(),
-				Params:    strings.Join(extractParams(directive), " "),
-			}
-			ngxServer.Directives = append(ngxServer.Directives, ngxDirective)
-		}
-
-		// Copy http2 directives
-		http2Directives := extractDirectives(server, "http2")
-		for _, directive := range http2Directives {
-			ngxDirective := &nginx.NgxDirective{
-				Directive: directive.GetName(),
-				Params:    strings.Join(extractParams(directive), " "),
+				Raw:       dumpMaintenanceDirective(directive),
 			}
 			ngxServer.Directives = append(ngxServer.Directives, ngxDirective)
 		}
@@ -311,6 +306,248 @@ func extractDirectives(server config.IDirective, name string) []config.IDirectiv
 	}
 
 	return directives
+}
+
+// extractMaintenanceServerDirectives extracts directives needed by the generated maintenance server.
+func extractMaintenanceServerDirectives(server config.IDirective, baseDir string) []config.IDirective {
+	expander := newMaintenanceIncludeExpander(baseDir)
+	var directives []config.IDirective
+
+	if server.GetBlock() == nil {
+		return directives
+	}
+
+	for _, directive := range server.GetBlock().GetDirectives() {
+		directives = append(directives, expander.extractServerDirective(directive, 0)...)
+	}
+
+	return directives
+}
+
+func newMaintenanceIncludeExpander(baseDir string) *maintenanceIncludeExpander {
+	confDir := nginx.GetConfPath()
+	if baseDir == "" {
+		baseDir = confDir
+	}
+
+	return &maintenanceIncludeExpander{
+		baseDir: baseDir,
+		confDir: confDir,
+		visited: make(map[string]struct{}),
+	}
+}
+
+func (e *maintenanceIncludeExpander) extractServerDirective(directive config.IDirective, depth int) []config.IDirective {
+	name := directive.GetName()
+
+	if _, ok := baseMaintenanceServerDirectives[name]; ok {
+		return []config.IDirective{directive}
+	}
+
+	if strings.HasPrefix(name, "ssl_") {
+		return []config.IDirective{directive}
+	}
+
+	if name == "include" {
+		return e.extractIncludeDirective(directive, depth)
+	}
+
+	return nil
+}
+
+func (e *maintenanceIncludeExpander) extractIncludeDirective(directive config.IDirective, depth int) []config.IDirective {
+	params := extractParams(directive)
+	if len(params) == 0 {
+		return nil
+	}
+
+	includePath := strings.Trim(params[0], `"'`)
+	if hasMaintenanceGlobMeta(includePath) {
+		return e.extractWildcardInclude(includePath, depth+1)
+	}
+
+	resolvedPath := e.resolveIncludePath(includePath)
+	if !e.isAllowedSingleInclude(resolvedPath) {
+		logger.Debugf("%s: skipped disallowed include %s", maintenanceIncludeDebugLogPrefix, resolvedPath)
+		return nil
+	}
+
+	return e.extractIncludeFile(resolvedPath, depth+1)
+}
+
+func (e *maintenanceIncludeExpander) extractWildcardInclude(includePath string, depth int) []config.IDirective {
+	pattern := e.resolveWildcardIncludePath(includePath)
+	staticDir := maintenanceGlobStaticDir(pattern)
+	if staticDir == "" || !helper.IsUnderDirectory(staticDir, e.confDir) {
+		logger.Debugf("%s: skipped disallowed wildcard include %s", maintenanceIncludeDebugLogPrefix, pattern)
+		return nil
+	}
+
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		logger.Debugf("%s: failed to expand wildcard %s: %v", maintenanceIncludeDebugLogPrefix, pattern, err)
+		return nil
+	}
+	sort.Strings(matches)
+
+	var directives []config.IDirective
+	allowedMatches := 0
+	for _, match := range matches {
+		if !e.isAllowedWildcardMatch(match) {
+			logger.Debugf("%s: skipped disallowed wildcard match %s", maintenanceIncludeDebugLogPrefix, match)
+			continue
+		}
+		if allowedMatches >= maintenanceMaxWildcardMatches {
+			logger.Debugf(
+				"%s: wildcard %s exceeded %d allowed files",
+				maintenanceIncludeDebugLogPrefix,
+				pattern,
+				maintenanceMaxWildcardMatches,
+			)
+			break
+		}
+		allowedMatches++
+
+		directives = append(directives, e.extractIncludeFile(match, depth)...)
+	}
+
+	return directives
+}
+
+func (e *maintenanceIncludeExpander) isAllowedWildcardMatch(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		logger.Debugf("%s: failed to stat wildcard match %s: %v", maintenanceIncludeDebugLogPrefix, path, err)
+		return false
+	}
+	if info.IsDir() {
+		return false
+	}
+
+	return helper.IsUnderDirectory(path, e.confDir)
+}
+
+func maintenanceGlobStaticDir(pattern string) string {
+	firstGlobIndex := strings.IndexAny(pattern, "*?[")
+	if firstGlobIndex == -1 {
+		return filepath.Dir(pattern)
+	}
+
+	staticPrefix := pattern[:firstGlobIndex]
+	if staticPrefix == "" {
+		return ""
+	}
+
+	return filepath.Clean(filepath.Dir(staticPrefix))
+}
+
+func (e *maintenanceIncludeExpander) resolveIncludePath(includePath string) string {
+	if filepath.IsAbs(includePath) {
+		return filepath.Clean(includePath)
+	}
+
+	candidate := filepath.Clean(filepath.Join(e.baseDir, includePath))
+	if _, err := os.Stat(candidate); err == nil {
+		return candidate
+	}
+
+	return filepath.Clean(filepath.Join(e.confDir, includePath))
+}
+
+func (e *maintenanceIncludeExpander) resolveWildcardIncludePath(includePath string) string {
+	if filepath.IsAbs(includePath) {
+		return filepath.Clean(includePath)
+	}
+
+	candidate := filepath.Clean(filepath.Join(e.baseDir, includePath))
+	if staticDir := maintenanceGlobStaticDir(candidate); staticDir != "" && helper.IsUnderDirectory(staticDir, e.confDir) {
+		if info, err := os.Stat(staticDir); err == nil && info.IsDir() {
+			return candidate
+		}
+	}
+
+	return filepath.Clean(filepath.Join(e.confDir, includePath))
+}
+
+func (e *maintenanceIncludeExpander) isAllowedSingleInclude(path string) bool {
+	cleanPath := filepath.Clean(path)
+	if cleanPath == certbotNginxTLSOptionsPath {
+		info, err := os.Lstat(cleanPath)
+		if err != nil {
+			logger.Debugf("%s: failed to stat certbot include %s: %v", maintenanceIncludeDebugLogPrefix, cleanPath, err)
+			return false
+		}
+		return info.Mode().IsRegular()
+	}
+
+	return helper.IsUnderDirectory(cleanPath, e.confDir)
+}
+
+func (e *maintenanceIncludeExpander) extractIncludeFile(path string, depth int) []config.IDirective {
+	if depth > maintenanceMaxIncludeDepth {
+		logger.Debugf("%s: skipped %s because include depth exceeded %d", maintenanceIncludeDebugLogPrefix, path, maintenanceMaxIncludeDepth)
+		return nil
+	}
+
+	cleanPath := filepath.Clean(path)
+	if _, ok := e.visited[cleanPath]; ok {
+		return nil
+	}
+	e.visited[cleanPath] = struct{}{}
+
+	content, err := os.ReadFile(cleanPath)
+	if err != nil {
+		logger.Debugf("%s: failed to read %s: %v", maintenanceIncludeDebugLogPrefix, cleanPath, err)
+		return nil
+	}
+
+	p := parser.NewStringParser(string(content), parser.WithSkipValidDirectivesErr())
+	conf, err := p.Parse()
+	if err != nil {
+		logger.Debugf("%s: failed to parse %s: %v", maintenanceIncludeDebugLogPrefix, cleanPath, err)
+		return nil
+	}
+
+	if conf.Block == nil {
+		return nil
+	}
+
+	var directives []config.IDirective
+	for _, directive := range conf.Block.GetDirectives() {
+		directives = append(directives, e.extractIncludedDirective(directive, filepath.Dir(cleanPath), depth)...)
+	}
+
+	return directives
+}
+
+func (e *maintenanceIncludeExpander) extractIncludedDirective(directive config.IDirective, includeBaseDir string, depth int) []config.IDirective {
+	name := directive.GetName()
+
+	if strings.HasPrefix(name, "ssl_") {
+		return []config.IDirective{directive}
+	}
+
+	if name != "include" {
+		return nil
+	}
+
+	previousBaseDir := e.baseDir
+	e.baseDir = includeBaseDir
+	defer func() {
+		e.baseDir = previousBaseDir
+	}()
+
+	return e.extractIncludeDirective(directive, depth)
+}
+
+func hasMaintenanceGlobMeta(path string) bool {
+	return strings.ContainsAny(path, "*?[")
+}
+
+func dumpMaintenanceDirective(directive config.IDirective) string {
+	style := *dumper.IndentedStyle
+	style.StartIndent = 0
+	return dumper.DumpDirective(directive, &style)
 }
 
 // extractParams extracts all parameters from a directive

--- a/internal/site/maintenance.go
+++ b/internal/site/maintenance.go
@@ -46,7 +46,6 @@ const (
 var certbotNginxTLSOptionsPath = filepath.Clean("/etc/letsencrypt/options-ssl-nginx.conf")
 
 type maintenanceIncludeExpander struct {
-	baseDir string
 	confDir string
 	visited map[string]struct{}
 }
@@ -310,7 +309,8 @@ func extractDirectives(server config.IDirective, name string) []config.IDirectiv
 
 // extractMaintenanceServerDirectives extracts directives needed by the generated maintenance server.
 func extractMaintenanceServerDirectives(server config.IDirective, baseDir string) []config.IDirective {
-	expander := newMaintenanceIncludeExpander(baseDir)
+	expander := newMaintenanceIncludeExpander()
+	initialBaseDir := resolveMaintenanceBaseDir(baseDir, expander.confDir)
 	var directives []config.IDirective
 
 	if server.GetBlock() == nil {
@@ -318,30 +318,33 @@ func extractMaintenanceServerDirectives(server config.IDirective, baseDir string
 	}
 
 	for _, directive := range server.GetBlock().GetDirectives() {
-		directives = append(directives, expander.extractServerDirective(directive, 0)...)
+		directives = append(directives, expander.extractServerDirective(directive, initialBaseDir, 0)...)
 	}
 
 	return directives
 }
 
-func newMaintenanceIncludeExpander(baseDir string) *maintenanceIncludeExpander {
-	confDir := filepath.Clean(nginx.GetConfPath())
-	resolvedBaseDir := confDir
-	if baseDir != "" {
-		candidateBaseDir := filepath.Clean(baseDir)
-		if helper.IsUnderDirectory(candidateBaseDir, confDir) {
-			resolvedBaseDir = candidateBaseDir
-		}
-	}
-
+func newMaintenanceIncludeExpander() *maintenanceIncludeExpander {
 	return &maintenanceIncludeExpander{
-		baseDir: resolvedBaseDir,
-		confDir: confDir,
+		confDir: filepath.Clean(nginx.GetConfPath()),
 		visited: make(map[string]struct{}),
 	}
 }
 
-func (e *maintenanceIncludeExpander) extractServerDirective(directive config.IDirective, depth int) []config.IDirective {
+// resolveMaintenanceBaseDir validates a caller-supplied include base directory and falls
+// back to confDir if it is empty or escapes the nginx configuration directory.
+func resolveMaintenanceBaseDir(baseDir, confDir string) string {
+	if baseDir == "" {
+		return confDir
+	}
+	candidate := filepath.Clean(baseDir)
+	if helper.IsUnderDirectory(candidate, confDir) {
+		return candidate
+	}
+	return confDir
+}
+
+func (e *maintenanceIncludeExpander) extractServerDirective(directive config.IDirective, baseDir string, depth int) []config.IDirective {
 	name := directive.GetName()
 
 	if _, ok := baseMaintenanceServerDirectives[name]; ok {
@@ -353,13 +356,13 @@ func (e *maintenanceIncludeExpander) extractServerDirective(directive config.IDi
 	}
 
 	if name == "include" {
-		return e.extractIncludeDirective(directive, depth)
+		return e.extractIncludeDirective(directive, baseDir, depth)
 	}
 
 	return nil
 }
 
-func (e *maintenanceIncludeExpander) extractIncludeDirective(directive config.IDirective, depth int) []config.IDirective {
+func (e *maintenanceIncludeExpander) extractIncludeDirective(directive config.IDirective, baseDir string, depth int) []config.IDirective {
 	params := extractParams(directive)
 	if len(params) == 0 {
 		return nil
@@ -367,10 +370,10 @@ func (e *maintenanceIncludeExpander) extractIncludeDirective(directive config.ID
 
 	includePath := strings.Trim(params[0], `"'`)
 	if hasMaintenanceGlobMeta(includePath) {
-		return e.extractWildcardInclude(includePath, depth+1)
+		return e.extractWildcardInclude(includePath, baseDir, depth+1)
 	}
 
-	resolvedPath := e.resolveIncludePath(includePath)
+	resolvedPath := e.resolveIncludePath(includePath, baseDir)
 	if !e.isAllowedSingleInclude(resolvedPath) {
 		logger.Debugf("%s: skipped disallowed include %s", maintenanceIncludeDebugLogPrefix, resolvedPath)
 		return nil
@@ -379,8 +382,8 @@ func (e *maintenanceIncludeExpander) extractIncludeDirective(directive config.ID
 	return e.extractIncludeFile(resolvedPath, depth+1)
 }
 
-func (e *maintenanceIncludeExpander) extractWildcardInclude(includePath string, depth int) []config.IDirective {
-	pattern := e.resolveWildcardIncludePath(includePath)
+func (e *maintenanceIncludeExpander) extractWildcardInclude(includePath, baseDir string, depth int) []config.IDirective {
+	pattern := e.resolveWildcardIncludePath(includePath, baseDir)
 	staticDir := maintenanceGlobStaticDir(pattern)
 	if staticDir == "" || !helper.IsUnderDirectory(staticDir, e.confDir) {
 		logger.Debugf("%s: skipped disallowed wildcard include %s", maintenanceIncludeDebugLogPrefix, pattern)
@@ -446,15 +449,18 @@ func maintenanceGlobStaticDir(pattern string) string {
 		return ""
 	}
 
-	return filepath.Clean(filepath.Dir(staticPrefix))
+	return filepath.Dir(staticPrefix)
 }
 
-func (e *maintenanceIncludeExpander) resolveIncludePath(includePath string) string {
+func (e *maintenanceIncludeExpander) resolveIncludePath(includePath, baseDir string) string {
 	if filepath.IsAbs(includePath) {
 		return filepath.Clean(includePath)
 	}
 
-	candidate := filepath.Clean(filepath.Join(e.baseDir, includePath))
+	// filepath.Join already cleans its output; check baseDir-relative location first
+	// and fall back to confDir-relative only if it does not exist (nginx include
+	// resolution semantics).
+	candidate := filepath.Join(baseDir, includePath)
 	if helper.IsUnderDirectory(candidate, e.confDir) {
 		if _, err := os.Stat(candidate); err == nil {
 			return candidate
@@ -464,27 +470,21 @@ func (e *maintenanceIncludeExpander) resolveIncludePath(includePath string) stri
 	return e.resolveFallbackIncludePath(includePath)
 }
 
-func (e *maintenanceIncludeExpander) resolveWildcardIncludePath(includePath string) string {
+func (e *maintenanceIncludeExpander) resolveWildcardIncludePath(includePath, baseDir string) string {
+	var candidate string
 	if filepath.IsAbs(includePath) {
-		candidate := filepath.Clean(includePath)
-		staticDir := maintenanceGlobStaticDir(candidate)
-		if staticDir == "" || !helper.IsUnderDirectory(staticDir, e.confDir) {
-			return e.resolveFallbackIncludePath(includePath)
-		}
-
-		if info, err := os.Stat(staticDir); err == nil && info.IsDir() {
-			return candidate
-		}
-
-		return e.resolveFallbackIncludePath(includePath)
+		candidate = filepath.Clean(includePath)
+	} else {
+		candidate = filepath.Join(baseDir, includePath)
 	}
 
-	candidate := filepath.Clean(filepath.Join(e.baseDir, includePath))
 	staticDir := maintenanceGlobStaticDir(candidate)
 	if staticDir == "" || !helper.IsUnderDirectory(staticDir, e.confDir) {
 		return e.resolveFallbackIncludePath(includePath)
 	}
 
+	// Stat the static prefix so a baseDir-relative wildcard that targets a
+	// nonexistent directory still falls back to the confDir-relative pattern.
 	if info, err := os.Stat(staticDir); err == nil && info.IsDir() {
 		return candidate
 	}
@@ -493,7 +493,7 @@ func (e *maintenanceIncludeExpander) resolveWildcardIncludePath(includePath stri
 }
 
 func (e *maintenanceIncludeExpander) resolveFallbackIncludePath(includePath string) string {
-	fallback := filepath.Clean(filepath.Join(e.confDir, includePath))
+	fallback := filepath.Join(e.confDir, includePath)
 	if hasMaintenanceGlobMeta(fallback) {
 		staticDir := maintenanceGlobStaticDir(fallback)
 		if staticDir != "" && helper.IsUnderDirectory(staticDir, e.confDir) {
@@ -557,14 +557,15 @@ func (e *maintenanceIncludeExpander) extractIncludeFile(path string, depth int) 
 	}
 
 	var directives []config.IDirective
+	childBaseDir := filepath.Dir(cleanPath)
 	for _, directive := range conf.Block.GetDirectives() {
-		directives = append(directives, e.extractIncludedDirective(directive, filepath.Dir(cleanPath), depth)...)
+		directives = append(directives, e.extractIncludedDirective(directive, childBaseDir, depth)...)
 	}
 
 	return directives
 }
 
-func (e *maintenanceIncludeExpander) extractIncludedDirective(directive config.IDirective, includeBaseDir string, depth int) []config.IDirective {
+func (e *maintenanceIncludeExpander) extractIncludedDirective(directive config.IDirective, baseDir string, depth int) []config.IDirective {
 	name := directive.GetName()
 
 	if strings.HasPrefix(name, "ssl_") {
@@ -575,13 +576,7 @@ func (e *maintenanceIncludeExpander) extractIncludedDirective(directive config.I
 		return nil
 	}
 
-	previousBaseDir := e.baseDir
-	e.baseDir = includeBaseDir
-	defer func() {
-		e.baseDir = previousBaseDir
-	}()
-
-	return e.extractIncludeDirective(directive, depth)
+	return e.extractIncludeDirective(directive, baseDir, depth)
 }
 
 func hasMaintenanceGlobMeta(path string) bool {

--- a/internal/site/maintenance.go
+++ b/internal/site/maintenance.go
@@ -325,13 +325,17 @@ func extractMaintenanceServerDirectives(server config.IDirective, baseDir string
 }
 
 func newMaintenanceIncludeExpander(baseDir string) *maintenanceIncludeExpander {
-	confDir := nginx.GetConfPath()
-	if baseDir == "" {
-		baseDir = confDir
+	confDir := filepath.Clean(nginx.GetConfPath())
+	resolvedBaseDir := confDir
+	if baseDir != "" {
+		candidateBaseDir := filepath.Clean(baseDir)
+		if helper.IsUnderDirectory(candidateBaseDir, confDir) {
+			resolvedBaseDir = candidateBaseDir
+		}
 	}
 
 	return &maintenanceIncludeExpander{
-		baseDir: baseDir,
+		baseDir: resolvedBaseDir,
 		confDir: confDir,
 		visited: make(map[string]struct{}),
 	}
@@ -415,6 +419,10 @@ func (e *maintenanceIncludeExpander) extractWildcardInclude(includePath string, 
 }
 
 func (e *maintenanceIncludeExpander) isAllowedWildcardMatch(path string) bool {
+	if !helper.IsUnderDirectory(path, e.confDir) {
+		return false
+	}
+
 	info, err := os.Stat(path)
 	if err != nil {
 		logger.Debugf("%s: failed to stat wildcard match %s: %v", maintenanceIncludeDebugLogPrefix, path, err)
@@ -424,7 +432,7 @@ func (e *maintenanceIncludeExpander) isAllowedWildcardMatch(path string) bool {
 		return false
 	}
 
-	return helper.IsUnderDirectory(path, e.confDir)
+	return true
 }
 
 func maintenanceGlobStaticDir(pattern string) string {
@@ -447,26 +455,57 @@ func (e *maintenanceIncludeExpander) resolveIncludePath(includePath string) stri
 	}
 
 	candidate := filepath.Clean(filepath.Join(e.baseDir, includePath))
-	if _, err := os.Stat(candidate); err == nil {
-		return candidate
-	}
-
-	return filepath.Clean(filepath.Join(e.confDir, includePath))
-}
-
-func (e *maintenanceIncludeExpander) resolveWildcardIncludePath(includePath string) string {
-	if filepath.IsAbs(includePath) {
-		return filepath.Clean(includePath)
-	}
-
-	candidate := filepath.Clean(filepath.Join(e.baseDir, includePath))
-	if staticDir := maintenanceGlobStaticDir(candidate); staticDir != "" && helper.IsUnderDirectory(staticDir, e.confDir) {
-		if info, err := os.Stat(staticDir); err == nil && info.IsDir() {
+	if helper.IsUnderDirectory(candidate, e.confDir) {
+		if _, err := os.Stat(candidate); err == nil {
 			return candidate
 		}
 	}
 
-	return filepath.Clean(filepath.Join(e.confDir, includePath))
+	return e.resolveFallbackIncludePath(includePath)
+}
+
+func (e *maintenanceIncludeExpander) resolveWildcardIncludePath(includePath string) string {
+	if filepath.IsAbs(includePath) {
+		candidate := filepath.Clean(includePath)
+		staticDir := maintenanceGlobStaticDir(candidate)
+		if staticDir == "" || !helper.IsUnderDirectory(staticDir, e.confDir) {
+			return e.resolveFallbackIncludePath(includePath)
+		}
+
+		if info, err := os.Stat(staticDir); err == nil && info.IsDir() {
+			return candidate
+		}
+
+		return e.resolveFallbackIncludePath(includePath)
+	}
+
+	candidate := filepath.Clean(filepath.Join(e.baseDir, includePath))
+	staticDir := maintenanceGlobStaticDir(candidate)
+	if staticDir == "" || !helper.IsUnderDirectory(staticDir, e.confDir) {
+		return e.resolveFallbackIncludePath(includePath)
+	}
+
+	if info, err := os.Stat(staticDir); err == nil && info.IsDir() {
+		return candidate
+	}
+
+	return e.resolveFallbackIncludePath(includePath)
+}
+
+func (e *maintenanceIncludeExpander) resolveFallbackIncludePath(includePath string) string {
+	fallback := filepath.Clean(filepath.Join(e.confDir, includePath))
+	if hasMaintenanceGlobMeta(fallback) {
+		staticDir := maintenanceGlobStaticDir(fallback)
+		if staticDir != "" && helper.IsUnderDirectory(staticDir, e.confDir) {
+			return fallback
+		}
+		return e.confDir
+	}
+
+	if helper.IsUnderDirectory(fallback, e.confDir) {
+		return fallback
+	}
+	return e.confDir
 }
 
 func (e *maintenanceIncludeExpander) isAllowedSingleInclude(path string) bool {
@@ -490,6 +529,11 @@ func (e *maintenanceIncludeExpander) extractIncludeFile(path string, depth int) 
 	}
 
 	cleanPath := filepath.Clean(path)
+	if !e.isAllowedSingleInclude(cleanPath) {
+		logger.Debugf("%s: skipped disallowed include file %s", maintenanceIncludeDebugLogPrefix, cleanPath)
+		return nil
+	}
+
 	if _, ok := e.visited[cleanPath]; ok {
 		return nil
 	}

--- a/internal/site/maintenance_test.go
+++ b/internal/site/maintenance_test.go
@@ -12,20 +12,33 @@ import (
 	cSettings "github.com/uozi-tech/cosy/settings"
 )
 
-func TestCreateMaintenanceConfig_PreservesForwardedHost(t *testing.T) {
+// setupMaintenanceTestSettings snapshots and restores the settings globals mutated
+// by maintenance-config tests, then installs canonical test values. Pass
+// nginxConfigDir == "" to leave settings.NginxSettings.ConfigDir at its prior
+// value (still restored on cleanup).
+func setupMaintenanceTestSettings(t *testing.T, nginxConfigDir string) {
+	t.Helper()
 	originalPort := cSettings.ServerSettings.Port
 	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
 	originalChallengePort := settings.CertSettings.HTTPChallengePort
-
+	originalConfigDir := settings.NginxSettings.ConfigDir
 	t.Cleanup(func() {
 		cSettings.ServerSettings.Port = originalPort
 		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
 		settings.CertSettings.HTTPChallengePort = originalChallengePort
+		settings.NginxSettings.ConfigDir = originalConfigDir
 	})
 
+	if nginxConfigDir != "" {
+		settings.NginxSettings.ConfigDir = nginxConfigDir
+	}
 	cSettings.ServerSettings.Port = 9000
 	cSettings.ServerSettings.EnableHTTPS = false
 	settings.CertSettings.HTTPChallengePort = "9180"
+}
+
+func TestCreateMaintenanceConfig_PreservesForwardedHost(t *testing.T) {
+	setupMaintenanceTestSettings(t, "")
 
 	p := parser.NewStringParser(`server {
     listen 80;
@@ -53,18 +66,6 @@ func TestCreateMaintenanceConfig_PreservesForwardedHost(t *testing.T) {
 }
 
 func TestCreateMaintenanceConfig_PreservesTLSHandshakeDirectives(t *testing.T) {
-	originalPort := cSettings.ServerSettings.Port
-	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
-	originalChallengePort := settings.CertSettings.HTTPChallengePort
-	originalConfigDir := settings.NginxSettings.ConfigDir
-
-	t.Cleanup(func() {
-		cSettings.ServerSettings.Port = originalPort
-		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
-		settings.CertSettings.HTTPChallengePort = originalChallengePort
-		settings.NginxSettings.ConfigDir = originalConfigDir
-	})
-
 	nginxConfigDir := t.TempDir()
 	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
 	snippetsDir := filepath.Join(nginxConfigDir, "snippets")
@@ -83,10 +84,7 @@ location /unexpected {
 		t.Fatalf("failed to write ssl include: %v", err)
 	}
 
-	settings.NginxSettings.ConfigDir = nginxConfigDir
-	cSettings.ServerSettings.Port = 9000
-	cSettings.ServerSettings.EnableHTTPS = false
-	settings.CertSettings.HTTPChallengePort = "9180"
+	setupMaintenanceTestSettings(t, nginxConfigDir)
 
 	p := parser.NewStringParser(`server {
     listen 443 ssl;
@@ -134,18 +132,6 @@ location /unexpected {
 }
 
 func TestCreateMaintenanceConfig_RecursivelyExpandsTLSIncludesAndSkipsCycles(t *testing.T) {
-	originalPort := cSettings.ServerSettings.Port
-	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
-	originalChallengePort := settings.CertSettings.HTTPChallengePort
-	originalConfigDir := settings.NginxSettings.ConfigDir
-
-	t.Cleanup(func() {
-		cSettings.ServerSettings.Port = originalPort
-		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
-		settings.CertSettings.HTTPChallengePort = originalChallengePort
-		settings.NginxSettings.ConfigDir = originalConfigDir
-	})
-
 	nginxConfigDir := t.TempDir()
 	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
 	snippetsDir := filepath.Join(nginxConfigDir, "snippets")
@@ -167,10 +153,7 @@ ssl_session_timeout 10m;
 		t.Fatalf("failed to write b.conf: %v", err)
 	}
 
-	settings.NginxSettings.ConfigDir = nginxConfigDir
-	cSettings.ServerSettings.Port = 9000
-	cSettings.ServerSettings.EnableHTTPS = false
-	settings.CertSettings.HTTPChallengePort = "9180"
+	setupMaintenanceTestSettings(t, nginxConfigDir)
 
 	p := parser.NewStringParser(`server {
     listen 443 ssl;
@@ -198,18 +181,6 @@ ssl_session_timeout 10m;
 }
 
 func TestCreateMaintenanceConfig_ExpandsNestedRelativeWildcardIncludes(t *testing.T) {
-	originalPort := cSettings.ServerSettings.Port
-	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
-	originalChallengePort := settings.CertSettings.HTTPChallengePort
-	originalConfigDir := settings.NginxSettings.ConfigDir
-
-	t.Cleanup(func() {
-		cSettings.ServerSettings.Port = originalPort
-		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
-		settings.CertSettings.HTTPChallengePort = originalChallengePort
-		settings.NginxSettings.ConfigDir = originalConfigDir
-	})
-
 	nginxConfigDir := t.TempDir()
 	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
 	snippetsDir := filepath.Join(nginxConfigDir, "snippets")
@@ -227,10 +198,7 @@ func TestCreateMaintenanceConfig_ExpandsNestedRelativeWildcardIncludes(t *testin
 		t.Fatalf("failed to write nested wildcard include: %v", err)
 	}
 
-	settings.NginxSettings.ConfigDir = nginxConfigDir
-	cSettings.ServerSettings.Port = 9000
-	cSettings.ServerSettings.EnableHTTPS = false
-	settings.CertSettings.HTTPChallengePort = "9180"
+	setupMaintenanceTestSettings(t, nginxConfigDir)
 
 	p := parser.NewStringParser(`server {
     listen 443 ssl;
@@ -255,18 +223,6 @@ func TestCreateMaintenanceConfig_ExpandsNestedRelativeWildcardIncludes(t *testin
 }
 
 func TestCreateMaintenanceConfig_SkipsServerDirectivesFromIncludes(t *testing.T) {
-	originalPort := cSettings.ServerSettings.Port
-	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
-	originalChallengePort := settings.CertSettings.HTTPChallengePort
-	originalConfigDir := settings.NginxSettings.ConfigDir
-
-	t.Cleanup(func() {
-		cSettings.ServerSettings.Port = originalPort
-		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
-		settings.CertSettings.HTTPChallengePort = originalChallengePort
-		settings.NginxSettings.ConfigDir = originalConfigDir
-	})
-
 	nginxConfigDir := t.TempDir()
 	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
 	snippetsDir := filepath.Join(nginxConfigDir, "snippets")
@@ -284,10 +240,7 @@ ssl_protocols TLSv1.3;
 		t.Fatalf("failed to write common include: %v", err)
 	}
 
-	settings.NginxSettings.ConfigDir = nginxConfigDir
-	cSettings.ServerSettings.Port = 9000
-	cSettings.ServerSettings.EnableHTTPS = false
-	settings.CertSettings.HTTPChallengePort = "9180"
+	setupMaintenanceTestSettings(t, nginxConfigDir)
 
 	p := parser.NewStringParser(`server {
     listen 443 ssl;
@@ -318,28 +271,13 @@ ssl_protocols TLSv1.3;
 }
 
 func TestCreateMaintenanceConfig_PreservesTLSBlockDirectives(t *testing.T) {
-	originalPort := cSettings.ServerSettings.Port
-	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
-	originalChallengePort := settings.CertSettings.HTTPChallengePort
-	originalConfigDir := settings.NginxSettings.ConfigDir
-
-	t.Cleanup(func() {
-		cSettings.ServerSettings.Port = originalPort
-		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
-		settings.CertSettings.HTTPChallengePort = originalChallengePort
-		settings.NginxSettings.ConfigDir = originalConfigDir
-	})
-
 	nginxConfigDir := t.TempDir()
 	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
 	if err := os.MkdirAll(sitesAvailableDir, 0755); err != nil {
 		t.Fatalf("failed to create sites-available dir: %v", err)
 	}
 
-	settings.NginxSettings.ConfigDir = nginxConfigDir
-	cSettings.ServerSettings.Port = 9000
-	cSettings.ServerSettings.EnableHTTPS = false
-	settings.CertSettings.HTTPChallengePort = "9180"
+	setupMaintenanceTestSettings(t, nginxConfigDir)
 
 	p := parser.NewStringParser(`server {
     listen 443 ssl;
@@ -361,28 +299,13 @@ func TestCreateMaintenanceConfig_PreservesTLSBlockDirectives(t *testing.T) {
 }
 
 func TestCreateMaintenanceConfig_PreservesLuaBlockWithSemicolonsAndBraces(t *testing.T) {
-	originalPort := cSettings.ServerSettings.Port
-	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
-	originalChallengePort := settings.CertSettings.HTTPChallengePort
-	originalConfigDir := settings.NginxSettings.ConfigDir
-
-	t.Cleanup(func() {
-		cSettings.ServerSettings.Port = originalPort
-		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
-		settings.CertSettings.HTTPChallengePort = originalChallengePort
-		settings.NginxSettings.ConfigDir = originalConfigDir
-	})
-
 	nginxConfigDir := t.TempDir()
 	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
 	if err := os.MkdirAll(sitesAvailableDir, 0755); err != nil {
 		t.Fatalf("failed to create sites-available dir: %v", err)
 	}
 
-	settings.NginxSettings.ConfigDir = nginxConfigDir
-	cSettings.ServerSettings.Port = 9000
-	cSettings.ServerSettings.EnableHTTPS = false
-	settings.CertSettings.HTTPChallengePort = "9180"
+	setupMaintenanceTestSettings(t, nginxConfigDir)
 
 	// Regression guard for Raw-field fidelity: the lua block contains both a
 	// statement-terminator (;) and a nested {} literal that could trip a naive
@@ -428,28 +351,13 @@ func TestCreateMaintenanceConfig_PreservesLuaBlockWithSemicolonsAndBraces(t *tes
 }
 
 func TestCreateMaintenanceConfig_PreservesQuotedTLSDirectiveParams(t *testing.T) {
-	originalPort := cSettings.ServerSettings.Port
-	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
-	originalChallengePort := settings.CertSettings.HTTPChallengePort
-	originalConfigDir := settings.NginxSettings.ConfigDir
-
-	t.Cleanup(func() {
-		cSettings.ServerSettings.Port = originalPort
-		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
-		settings.CertSettings.HTTPChallengePort = originalChallengePort
-		settings.NginxSettings.ConfigDir = originalConfigDir
-	})
-
 	nginxConfigDir := t.TempDir()
 	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
 	if err := os.MkdirAll(sitesAvailableDir, 0755); err != nil {
 		t.Fatalf("failed to create sites-available dir: %v", err)
 	}
 
-	settings.NginxSettings.ConfigDir = nginxConfigDir
-	cSettings.ServerSettings.Port = 9000
-	cSettings.ServerSettings.EnableHTTPS = false
-	settings.CertSettings.HTTPChallengePort = "9180"
+	setupMaintenanceTestSettings(t, nginxConfigDir)
 
 	p := parser.NewStringParser(`server {
     listen 443 ssl;
@@ -475,18 +383,6 @@ func TestCreateMaintenanceConfig_PreservesQuotedTLSDirectiveParams(t *testing.T)
 }
 
 func TestCreateMaintenanceConfig_ExpandsWildcardTLSIncludesInSortedOrder(t *testing.T) {
-	originalPort := cSettings.ServerSettings.Port
-	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
-	originalChallengePort := settings.CertSettings.HTTPChallengePort
-	originalConfigDir := settings.NginxSettings.ConfigDir
-
-	t.Cleanup(func() {
-		cSettings.ServerSettings.Port = originalPort
-		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
-		settings.CertSettings.HTTPChallengePort = originalChallengePort
-		settings.NginxSettings.ConfigDir = originalConfigDir
-	})
-
 	nginxConfigDir := t.TempDir()
 	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
 	tlsDir := filepath.Join(nginxConfigDir, "snippets", "tls")
@@ -507,10 +403,7 @@ func TestCreateMaintenanceConfig_ExpandsWildcardTLSIncludesInSortedOrder(t *test
 		}
 	}
 
-	settings.NginxSettings.ConfigDir = nginxConfigDir
-	cSettings.ServerSettings.Port = 9000
-	cSettings.ServerSettings.EnableHTTPS = false
-	settings.CertSettings.HTTPChallengePort = "9180"
+	setupMaintenanceTestSettings(t, nginxConfigDir)
 
 	p := parser.NewStringParser(`server {
     listen 443 ssl;
@@ -541,18 +434,6 @@ func TestCreateMaintenanceConfig_ExpandsWildcardTLSIncludesInSortedOrder(t *test
 }
 
 func TestCreateMaintenanceConfig_SkipsWildcardIncludesOutsideNginxConfigDir(t *testing.T) {
-	originalPort := cSettings.ServerSettings.Port
-	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
-	originalChallengePort := settings.CertSettings.HTTPChallengePort
-	originalConfigDir := settings.NginxSettings.ConfigDir
-
-	t.Cleanup(func() {
-		cSettings.ServerSettings.Port = originalPort
-		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
-		settings.CertSettings.HTTPChallengePort = originalChallengePort
-		settings.NginxSettings.ConfigDir = originalConfigDir
-	})
-
 	nginxConfigDir := t.TempDir()
 	outsideDir := t.TempDir()
 	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
@@ -563,10 +444,7 @@ func TestCreateMaintenanceConfig_SkipsWildcardIncludesOutsideNginxConfigDir(t *t
 		t.Fatalf("failed to write outside include: %v", err)
 	}
 
-	settings.NginxSettings.ConfigDir = nginxConfigDir
-	cSettings.ServerSettings.Port = 9000
-	cSettings.ServerSettings.EnableHTTPS = false
-	settings.CertSettings.HTTPChallengePort = "9180"
+	setupMaintenanceTestSettings(t, nginxConfigDir)
 
 	p := parser.NewStringParser(fmt.Sprintf(`server {
     listen 443 ssl;
@@ -588,18 +466,6 @@ func TestCreateMaintenanceConfig_SkipsWildcardIncludesOutsideNginxConfigDir(t *t
 }
 
 func TestCreateMaintenanceConfig_LimitsWildcardIncludeMatches(t *testing.T) {
-	originalPort := cSettings.ServerSettings.Port
-	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
-	originalChallengePort := settings.CertSettings.HTTPChallengePort
-	originalConfigDir := settings.NginxSettings.ConfigDir
-
-	t.Cleanup(func() {
-		cSettings.ServerSettings.Port = originalPort
-		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
-		settings.CertSettings.HTTPChallengePort = originalChallengePort
-		settings.NginxSettings.ConfigDir = originalConfigDir
-	})
-
 	nginxConfigDir := t.TempDir()
 	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
 	tlsDir := filepath.Join(nginxConfigDir, "snippets", "tls")
@@ -618,10 +484,7 @@ func TestCreateMaintenanceConfig_LimitsWildcardIncludeMatches(t *testing.T) {
 		}
 	}
 
-	settings.NginxSettings.ConfigDir = nginxConfigDir
-	cSettings.ServerSettings.Port = 9000
-	cSettings.ServerSettings.EnableHTTPS = false
-	settings.CertSettings.HTTPChallengePort = "9180"
+	setupMaintenanceTestSettings(t, nginxConfigDir)
 
 	p := parser.NewStringParser(`server {
     listen 443 ssl;
@@ -646,18 +509,6 @@ func TestCreateMaintenanceConfig_LimitsWildcardIncludeMatches(t *testing.T) {
 }
 
 func TestCreateMaintenanceConfig_LimitsWildcardIncludeMatchesAfterFiltering(t *testing.T) {
-	originalPort := cSettings.ServerSettings.Port
-	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
-	originalChallengePort := settings.CertSettings.HTTPChallengePort
-	originalConfigDir := settings.NginxSettings.ConfigDir
-
-	t.Cleanup(func() {
-		cSettings.ServerSettings.Port = originalPort
-		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
-		settings.CertSettings.HTTPChallengePort = originalChallengePort
-		settings.NginxSettings.ConfigDir = originalConfigDir
-	})
-
 	nginxConfigDir := t.TempDir()
 	outsideDir := t.TempDir()
 	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
@@ -683,10 +534,7 @@ func TestCreateMaintenanceConfig_LimitsWildcardIncludeMatchesAfterFiltering(t *t
 		t.Fatalf("failed to write legal wildcard include: %v", err)
 	}
 
-	settings.NginxSettings.ConfigDir = nginxConfigDir
-	cSettings.ServerSettings.Port = 9000
-	cSettings.ServerSettings.EnableHTTPS = false
-	settings.CertSettings.HTTPChallengePort = "9180"
+	setupMaintenanceTestSettings(t, nginxConfigDir)
 
 	p := parser.NewStringParser(`server {
     listen 443 ssl;
@@ -711,18 +559,6 @@ func TestCreateMaintenanceConfig_LimitsWildcardIncludeMatchesAfterFiltering(t *t
 }
 
 func TestCreateMaintenanceConfig_RejectsWildcardSymlinkEscape(t *testing.T) {
-	originalPort := cSettings.ServerSettings.Port
-	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
-	originalChallengePort := settings.CertSettings.HTTPChallengePort
-	originalConfigDir := settings.NginxSettings.ConfigDir
-
-	t.Cleanup(func() {
-		cSettings.ServerSettings.Port = originalPort
-		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
-		settings.CertSettings.HTTPChallengePort = originalChallengePort
-		settings.NginxSettings.ConfigDir = originalConfigDir
-	})
-
 	nginxConfigDir := t.TempDir()
 	outsideDir := t.TempDir()
 	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
@@ -742,10 +578,7 @@ func TestCreateMaintenanceConfig_RejectsWildcardSymlinkEscape(t *testing.T) {
 		t.Skipf("symlink creation is not available in this environment: %v", err)
 	}
 
-	settings.NginxSettings.ConfigDir = nginxConfigDir
-	cSettings.ServerSettings.Port = 9000
-	cSettings.ServerSettings.EnableHTTPS = false
-	settings.CertSettings.HTTPChallengePort = "9180"
+	setupMaintenanceTestSettings(t, nginxConfigDir)
 
 	p := parser.NewStringParser(`server {
     listen 443 ssl;
@@ -781,7 +614,7 @@ func TestMaintenanceIncludeExpander_AllowsCertbotOptionsPath(t *testing.T) {
 		t.Fatalf("failed to write certbot options path: %v", err)
 	}
 
-	expander := newMaintenanceIncludeExpander("")
+	expander := newMaintenanceIncludeExpander()
 
 	if !expander.isAllowedSingleInclude(certbotNginxTLSOptionsPath) {
 		t.Fatalf("expected certbot options path %q to be allowed", certbotNginxTLSOptionsPath)
@@ -816,46 +649,32 @@ func TestMaintenanceIncludeExpander_RejectsCertbotOptionsSymlink(t *testing.T) {
 		t.Skipf("symlink creation is not available in this environment: %v", err)
 	}
 
-	expander := newMaintenanceIncludeExpander("")
+	expander := newMaintenanceIncludeExpander()
 	if expander.isAllowedSingleInclude(certbotNginxTLSOptionsPath) {
 		t.Fatalf("expected certbot options symlink to be rejected")
 	}
 }
 
-func TestMaintenanceIncludeExpander_UsesBaseDirUnderConfigDir(t *testing.T) {
-	originalConfigDir := settings.NginxSettings.ConfigDir
-	t.Cleanup(func() {
-		settings.NginxSettings.ConfigDir = originalConfigDir
-	})
-
+func TestResolveMaintenanceBaseDir_UsesBaseDirUnderConfigDir(t *testing.T) {
 	nginxConfigDir := t.TempDir()
 	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
 	if err := os.MkdirAll(sitesAvailableDir, 0755); err != nil {
 		t.Fatalf("failed to create sites-available dir: %v", err)
 	}
 
-	settings.NginxSettings.ConfigDir = nginxConfigDir
-	expander := newMaintenanceIncludeExpander(sitesAvailableDir)
-
-	if expander.baseDir != filepath.Clean(sitesAvailableDir) {
-		t.Fatalf("baseDir = %q, want %q", expander.baseDir, filepath.Clean(sitesAvailableDir))
+	got := resolveMaintenanceBaseDir(sitesAvailableDir, filepath.Clean(nginxConfigDir))
+	if got != filepath.Clean(sitesAvailableDir) {
+		t.Fatalf("resolveMaintenanceBaseDir = %q, want %q", got, filepath.Clean(sitesAvailableDir))
 	}
 }
 
-func TestMaintenanceIncludeExpander_FallsBackWhenBaseDirEscapesConfigDir(t *testing.T) {
-	originalConfigDir := settings.NginxSettings.ConfigDir
-	t.Cleanup(func() {
-		settings.NginxSettings.ConfigDir = originalConfigDir
-	})
-
+func TestResolveMaintenanceBaseDir_FallsBackWhenBaseDirEscapesConfigDir(t *testing.T) {
 	nginxConfigDir := t.TempDir()
 	outsideDir := t.TempDir()
-	settings.NginxSettings.ConfigDir = nginxConfigDir
 
-	expander := newMaintenanceIncludeExpander(outsideDir)
-
-	if expander.baseDir != filepath.Clean(nginxConfigDir) {
-		t.Fatalf("baseDir = %q, want fallback to confDir %q", expander.baseDir, filepath.Clean(nginxConfigDir))
+	got := resolveMaintenanceBaseDir(outsideDir, filepath.Clean(nginxConfigDir))
+	if got != filepath.Clean(nginxConfigDir) {
+		t.Fatalf("resolveMaintenanceBaseDir = %q, want fallback to confDir %q", got, filepath.Clean(nginxConfigDir))
 	}
 }
 
@@ -877,13 +696,13 @@ func TestMaintenanceIncludeExpander_ResolveIncludePathSkipsExistingRelativeEscap
 	}
 
 	settings.NginxSettings.ConfigDir = nginxConfigDir
-	expander := newMaintenanceIncludeExpander(sitesAvailableDir)
+	expander := newMaintenanceIncludeExpander()
 	includePath, err := filepath.Rel(sitesAvailableDir, outsideFile)
 	if err != nil {
 		t.Fatalf("failed to build relative escape include path: %v", err)
 	}
 
-	resolvedPath := expander.resolveIncludePath(includePath)
+	resolvedPath := expander.resolveIncludePath(includePath, sitesAvailableDir)
 	if filepath.Clean(resolvedPath) == filepath.Clean(outsideFile) {
 		t.Fatalf("resolveIncludePath(%q) = %q, want existing path outside nginx config dir ignored", includePath, resolvedPath)
 	}
@@ -902,9 +721,9 @@ func TestMaintenanceIncludeExpander_ResolveIncludePathFallsBackToConfDirOnEscape
 	}
 
 	settings.NginxSettings.ConfigDir = nginxConfigDir
-	expander := newMaintenanceIncludeExpander(sitesAvailableDir)
+	expander := newMaintenanceIncludeExpander()
 
-	resolvedPath := expander.resolveIncludePath(filepath.Join("..", "..", "escape.conf"))
+	resolvedPath := expander.resolveIncludePath(filepath.Join("..", "..", "escape.conf"), sitesAvailableDir)
 	if resolvedPath != filepath.Clean(nginxConfigDir) {
 		t.Fatalf("resolveIncludePath escape fallback = %q, want confDir %q", resolvedPath, filepath.Clean(nginxConfigDir))
 	}
@@ -919,10 +738,10 @@ func TestMaintenanceIncludeExpander_ResolveWildcardIncludePathRejectsAbsoluteEsc
 	nginxConfigDir := t.TempDir()
 	outsideDir := t.TempDir()
 	settings.NginxSettings.ConfigDir = nginxConfigDir
-	expander := newMaintenanceIncludeExpander("")
+	expander := newMaintenanceIncludeExpander()
 
 	outsidePattern := filepath.Join(outsideDir, "*.conf")
-	resolvedPath := expander.resolveWildcardIncludePath(outsidePattern)
+	resolvedPath := expander.resolveWildcardIncludePath(outsidePattern, nginxConfigDir)
 	if filepath.Clean(resolvedPath) == filepath.Clean(outsidePattern) {
 		t.Fatalf("resolveWildcardIncludePath(%q) = %q, want absolute path outside nginx config dir rejected", outsidePattern, resolvedPath)
 	}
@@ -941,25 +760,13 @@ func TestMaintenanceIncludeExpander_ExtractIncludeFileRejectsDisallowedPath(t *t
 		t.Fatalf("failed to write outside include: %v", err)
 	}
 
-	expander := newMaintenanceIncludeExpander("")
+	expander := newMaintenanceIncludeExpander()
 	if directives := expander.extractIncludeFile(outsideFile, 1); len(directives) != 0 {
 		t.Fatalf("extractIncludeFile(%q) returned %d directives, want disallowed path rejected", outsideFile, len(directives))
 	}
 }
 
 func TestCreateMaintenanceConfig_EnforcesIncludeDepthLimit(t *testing.T) {
-	originalPort := cSettings.ServerSettings.Port
-	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
-	originalChallengePort := settings.CertSettings.HTTPChallengePort
-	originalConfigDir := settings.NginxSettings.ConfigDir
-
-	t.Cleanup(func() {
-		cSettings.ServerSettings.Port = originalPort
-		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
-		settings.CertSettings.HTTPChallengePort = originalChallengePort
-		settings.NginxSettings.ConfigDir = originalConfigDir
-	})
-
 	nginxConfigDir := t.TempDir()
 	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
 	snippetsDir := filepath.Join(nginxConfigDir, "snippets")
@@ -986,10 +793,7 @@ func TestCreateMaintenanceConfig_EnforcesIncludeDepthLimit(t *testing.T) {
 		}
 	}
 
-	settings.NginxSettings.ConfigDir = nginxConfigDir
-	cSettings.ServerSettings.Port = 9000
-	cSettings.ServerSettings.EnableHTTPS = false
-	settings.CertSettings.HTTPChallengePort = "9180"
+	setupMaintenanceTestSettings(t, nginxConfigDir)
 
 	p := parser.NewStringParser(`server {
     listen 443 ssl;
@@ -1024,18 +828,6 @@ func TestCreateMaintenanceConfig_EnforcesIncludeDepthLimit(t *testing.T) {
 }
 
 func TestCreateMaintenanceConfig_AcceptsAbsoluteIncludeInsideConfigDir(t *testing.T) {
-	originalPort := cSettings.ServerSettings.Port
-	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
-	originalChallengePort := settings.CertSettings.HTTPChallengePort
-	originalConfigDir := settings.NginxSettings.ConfigDir
-
-	t.Cleanup(func() {
-		cSettings.ServerSettings.Port = originalPort
-		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
-		settings.CertSettings.HTTPChallengePort = originalChallengePort
-		settings.NginxSettings.ConfigDir = originalConfigDir
-	})
-
 	nginxConfigDir := t.TempDir()
 	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
 	snippetsDir := filepath.Join(nginxConfigDir, "snippets")
@@ -1051,10 +843,7 @@ func TestCreateMaintenanceConfig_AcceptsAbsoluteIncludeInsideConfigDir(t *testin
 		t.Fatalf("failed to write absolute include: %v", err)
 	}
 
-	settings.NginxSettings.ConfigDir = nginxConfigDir
-	cSettings.ServerSettings.Port = 9000
-	cSettings.ServerSettings.EnableHTTPS = false
-	settings.CertSettings.HTTPChallengePort = "9180"
+	setupMaintenanceTestSettings(t, nginxConfigDir)
 
 	p := parser.NewStringParser(fmt.Sprintf(`server {
     listen 443 ssl;
@@ -1080,18 +869,6 @@ func TestCreateMaintenanceConfig_AcceptsAbsoluteIncludeInsideConfigDir(t *testin
 }
 
 func TestCreateMaintenanceConfig_IsolatesIncludeExpansionPerServer(t *testing.T) {
-	originalPort := cSettings.ServerSettings.Port
-	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
-	originalChallengePort := settings.CertSettings.HTTPChallengePort
-	originalConfigDir := settings.NginxSettings.ConfigDir
-
-	t.Cleanup(func() {
-		cSettings.ServerSettings.Port = originalPort
-		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
-		settings.CertSettings.HTTPChallengePort = originalChallengePort
-		settings.NginxSettings.ConfigDir = originalConfigDir
-	})
-
 	nginxConfigDir := t.TempDir()
 	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
 	snippetsDir := filepath.Join(nginxConfigDir, "snippets")
@@ -1105,10 +882,7 @@ func TestCreateMaintenanceConfig_IsolatesIncludeExpansionPerServer(t *testing.T)
 		t.Fatalf("failed to write shared include: %v", err)
 	}
 
-	settings.NginxSettings.ConfigDir = nginxConfigDir
-	cSettings.ServerSettings.Port = 9000
-	cSettings.ServerSettings.EnableHTTPS = false
-	settings.CertSettings.HTTPChallengePort = "9180"
+	setupMaintenanceTestSettings(t, nginxConfigDir)
 
 	p := parser.NewStringParser(`server {
     listen 443 ssl;

--- a/internal/site/maintenance_test.go
+++ b/internal/site/maintenance_test.go
@@ -1,6 +1,9 @@
 package site
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -34,7 +37,7 @@ func TestCreateMaintenanceConfig_PreservesForwardedHost(t *testing.T) {
 		t.Fatalf("Parse() error = %v", err)
 	}
 
-	content := createMaintenanceConfig(conf)
+	content := createMaintenanceConfig(conf, "")
 
 	if !strings.Contains(content, "proxy_set_header X-Forwarded-Host $http_host;") {
 		t.Fatalf("maintenance config = %q, want forwarded host header preservation", content)
@@ -46,5 +49,970 @@ func TestCreateMaintenanceConfig_PreservesForwardedHost(t *testing.T) {
 
 	if !strings.Contains(content, "proxy_pass http://127.0.0.1:9000;") {
 		t.Fatalf("maintenance config = %q, want proxy to nginx-ui backend", content)
+	}
+}
+
+func TestCreateMaintenanceConfig_PreservesTLSHandshakeDirectives(t *testing.T) {
+	originalPort := cSettings.ServerSettings.Port
+	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
+	originalChallengePort := settings.CertSettings.HTTPChallengePort
+	originalConfigDir := settings.NginxSettings.ConfigDir
+
+	t.Cleanup(func() {
+		cSettings.ServerSettings.Port = originalPort
+		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
+		settings.CertSettings.HTTPChallengePort = originalChallengePort
+		settings.NginxSettings.ConfigDir = originalConfigDir
+	})
+
+	nginxConfigDir := t.TempDir()
+	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
+	snippetsDir := filepath.Join(nginxConfigDir, "snippets")
+	if err := os.MkdirAll(sitesAvailableDir, 0755); err != nil {
+		t.Fatalf("failed to create sites-available dir: %v", err)
+	}
+	if err := os.MkdirAll(snippetsDir, 0755); err != nil {
+		t.Fatalf("failed to create snippets dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(snippetsDir, "ssl-options.conf"), []byte(`ssl_protocols TLSv1.2 TLSv1.3;
+ssl_ciphers HIGH:!aNULL:!MD5;
+location /unexpected {
+    proxy_pass http://127.0.0.1:12345;
+}
+`), 0644); err != nil {
+		t.Fatalf("failed to write ssl include: %v", err)
+	}
+
+	settings.NginxSettings.ConfigDir = nginxConfigDir
+	cSettings.ServerSettings.Port = 9000
+	cSettings.ServerSettings.EnableHTTPS = false
+	settings.CertSettings.HTTPChallengePort = "9180"
+
+	p := parser.NewStringParser(`server {
+    listen 443 ssl;
+    server_name example.com;
+    include snippets/ssl-options.conf;
+    include snippets/proxy.conf;
+    ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
+    ssl_prefer_server_ciphers on;
+}`, parser.WithSkipValidDirectivesErr())
+
+	conf, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	content := createMaintenanceConfig(conf, sitesAvailableDir)
+
+	expectedDirectives := []string{
+		"ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem;",
+		"ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;",
+		"ssl_prefer_server_ciphers on;",
+		"ssl_protocols TLSv1.2 TLSv1.3;",
+		"ssl_ciphers HIGH:!aNULL:!MD5;",
+	}
+
+	for _, expected := range expectedDirectives {
+		if !strings.Contains(content, expected) {
+			t.Fatalf("maintenance config = %q, want TLS directive %q", content, expected)
+		}
+	}
+
+	unexpectedContent := []string{
+		"include snippets/ssl-options.conf;",
+		"include snippets/proxy.conf;",
+		"proxy_pass http://127.0.0.1:12345;",
+		"location /unexpected",
+	}
+
+	for _, unexpected := range unexpectedContent {
+		if strings.Contains(content, unexpected) {
+			t.Fatalf("maintenance config = %q, want to exclude %q", content, unexpected)
+		}
+	}
+}
+
+func TestCreateMaintenanceConfig_RecursivelyExpandsTLSIncludesAndSkipsCycles(t *testing.T) {
+	originalPort := cSettings.ServerSettings.Port
+	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
+	originalChallengePort := settings.CertSettings.HTTPChallengePort
+	originalConfigDir := settings.NginxSettings.ConfigDir
+
+	t.Cleanup(func() {
+		cSettings.ServerSettings.Port = originalPort
+		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
+		settings.CertSettings.HTTPChallengePort = originalChallengePort
+		settings.NginxSettings.ConfigDir = originalConfigDir
+	})
+
+	nginxConfigDir := t.TempDir()
+	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
+	snippetsDir := filepath.Join(nginxConfigDir, "snippets")
+	if err := os.MkdirAll(sitesAvailableDir, 0755); err != nil {
+		t.Fatalf("failed to create sites-available dir: %v", err)
+	}
+	if err := os.MkdirAll(snippetsDir, 0755); err != nil {
+		t.Fatalf("failed to create snippets dir: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(snippetsDir, "a.conf"), []byte(`include b.conf;
+ssl_session_cache shared:SSL:10m;
+`), 0644); err != nil {
+		t.Fatalf("failed to write a.conf: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(snippetsDir, "b.conf"), []byte(`include a.conf;
+ssl_session_timeout 10m;
+`), 0644); err != nil {
+		t.Fatalf("failed to write b.conf: %v", err)
+	}
+
+	settings.NginxSettings.ConfigDir = nginxConfigDir
+	cSettings.ServerSettings.Port = 9000
+	cSettings.ServerSettings.EnableHTTPS = false
+	settings.CertSettings.HTTPChallengePort = "9180"
+
+	p := parser.NewStringParser(`server {
+    listen 443 ssl;
+    server_name example.com;
+    include snippets/a.conf;
+    ssl_certificate /cert.pem;
+    ssl_certificate_key /key.pem;
+}`, parser.WithSkipValidDirectivesErr())
+
+	conf, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	content := createMaintenanceConfig(conf, sitesAvailableDir)
+
+	for _, expected := range []string{
+		"ssl_session_cache shared:SSL:10m;",
+		"ssl_session_timeout 10m;",
+	} {
+		if !strings.Contains(content, expected) {
+			t.Fatalf("maintenance config = %q, want recursive TLS directive %q", content, expected)
+		}
+	}
+}
+
+func TestCreateMaintenanceConfig_ExpandsNestedRelativeWildcardIncludes(t *testing.T) {
+	originalPort := cSettings.ServerSettings.Port
+	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
+	originalChallengePort := settings.CertSettings.HTTPChallengePort
+	originalConfigDir := settings.NginxSettings.ConfigDir
+
+	t.Cleanup(func() {
+		cSettings.ServerSettings.Port = originalPort
+		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
+		settings.CertSettings.HTTPChallengePort = originalChallengePort
+		settings.NginxSettings.ConfigDir = originalConfigDir
+	})
+
+	nginxConfigDir := t.TempDir()
+	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
+	snippetsDir := filepath.Join(nginxConfigDir, "snippets")
+	tlsDir := filepath.Join(snippetsDir, "tls")
+	if err := os.MkdirAll(sitesAvailableDir, 0755); err != nil {
+		t.Fatalf("failed to create sites-available dir: %v", err)
+	}
+	if err := os.MkdirAll(tlsDir, 0755); err != nil {
+		t.Fatalf("failed to create tls dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(snippetsDir, "base.conf"), []byte("include tls/*.conf;\n"), 0644); err != nil {
+		t.Fatalf("failed to write base include: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tlsDir, "options.conf"), []byte("ssl_protocols TLSv1.2 TLSv1.3;\n"), 0644); err != nil {
+		t.Fatalf("failed to write nested wildcard include: %v", err)
+	}
+
+	settings.NginxSettings.ConfigDir = nginxConfigDir
+	cSettings.ServerSettings.Port = 9000
+	cSettings.ServerSettings.EnableHTTPS = false
+	settings.CertSettings.HTTPChallengePort = "9180"
+
+	p := parser.NewStringParser(`server {
+    listen 443 ssl;
+    server_name example.com;
+    include snippets/base.conf;
+    ssl_certificate /cert.pem;
+    ssl_certificate_key /key.pem;
+}`, parser.WithSkipValidDirectivesErr())
+
+	conf, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	content := createMaintenanceConfig(conf, sitesAvailableDir)
+	if !strings.Contains(content, "ssl_protocols TLSv1.2 TLSv1.3;") {
+		t.Fatalf("maintenance config = %q, want TLS directive from nested relative wildcard include", content)
+	}
+	if strings.Contains(content, "include tls/*.conf;") {
+		t.Fatalf("maintenance config = %q, want nested wildcard include omitted", content)
+	}
+}
+
+func TestCreateMaintenanceConfig_SkipsServerDirectivesFromIncludes(t *testing.T) {
+	originalPort := cSettings.ServerSettings.Port
+	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
+	originalChallengePort := settings.CertSettings.HTTPChallengePort
+	originalConfigDir := settings.NginxSettings.ConfigDir
+
+	t.Cleanup(func() {
+		cSettings.ServerSettings.Port = originalPort
+		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
+		settings.CertSettings.HTTPChallengePort = originalChallengePort
+		settings.NginxSettings.ConfigDir = originalConfigDir
+	})
+
+	nginxConfigDir := t.TempDir()
+	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
+	snippetsDir := filepath.Join(nginxConfigDir, "snippets")
+	if err := os.MkdirAll(sitesAvailableDir, 0755); err != nil {
+		t.Fatalf("failed to create sites-available dir: %v", err)
+	}
+	if err := os.MkdirAll(snippetsDir, 0755); err != nil {
+		t.Fatalf("failed to create snippets dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(snippetsDir, "common.conf"), []byte(`listen 8443 ssl;
+server_name internal.example.com;
+http2 on;
+ssl_protocols TLSv1.3;
+`), 0644); err != nil {
+		t.Fatalf("failed to write common include: %v", err)
+	}
+
+	settings.NginxSettings.ConfigDir = nginxConfigDir
+	cSettings.ServerSettings.Port = 9000
+	cSettings.ServerSettings.EnableHTTPS = false
+	settings.CertSettings.HTTPChallengePort = "9180"
+
+	p := parser.NewStringParser(`server {
+    listen 443 ssl;
+    server_name example.com;
+    include snippets/common.conf;
+    ssl_certificate /cert.pem;
+    ssl_certificate_key /key.pem;
+}`, parser.WithSkipValidDirectivesErr())
+
+	conf, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	content := createMaintenanceConfig(conf, sitesAvailableDir)
+	for _, unexpected := range []string{
+		"listen 8443 ssl;",
+		"server_name internal.example.com;",
+		"http2 on;",
+	} {
+		if strings.Contains(content, unexpected) {
+			t.Fatalf("maintenance config = %q, want include server directive %q omitted", content, unexpected)
+		}
+	}
+	if !strings.Contains(content, "ssl_protocols TLSv1.3;") {
+		t.Fatalf("maintenance config = %q, want TLS directive from include", content)
+	}
+}
+
+func TestCreateMaintenanceConfig_PreservesTLSBlockDirectives(t *testing.T) {
+	originalPort := cSettings.ServerSettings.Port
+	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
+	originalChallengePort := settings.CertSettings.HTTPChallengePort
+	originalConfigDir := settings.NginxSettings.ConfigDir
+
+	t.Cleanup(func() {
+		cSettings.ServerSettings.Port = originalPort
+		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
+		settings.CertSettings.HTTPChallengePort = originalChallengePort
+		settings.NginxSettings.ConfigDir = originalConfigDir
+	})
+
+	nginxConfigDir := t.TempDir()
+	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
+	if err := os.MkdirAll(sitesAvailableDir, 0755); err != nil {
+		t.Fatalf("failed to create sites-available dir: %v", err)
+	}
+
+	settings.NginxSettings.ConfigDir = nginxConfigDir
+	cSettings.ServerSettings.Port = 9000
+	cSettings.ServerSettings.EnableHTTPS = false
+	settings.CertSettings.HTTPChallengePort = "9180"
+
+	p := parser.NewStringParser(`server {
+    listen 443 ssl;
+    server_name example.com;
+    ssl_certificate_by_lua_block {
+        auto_ssl:ssl_certificate()
+    }
+}`, parser.WithSkipValidDirectivesErr())
+
+	conf, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	content := createMaintenanceConfig(conf, sitesAvailableDir)
+	if !strings.Contains(content, "ssl_certificate_by_lua_block") || !strings.Contains(content, "auto_ssl:ssl_certificate()") {
+		t.Fatalf("maintenance config = %q, want TLS block directive preserved", content)
+	}
+}
+
+func TestCreateMaintenanceConfig_PreservesLuaBlockWithSemicolonsAndBraces(t *testing.T) {
+	originalPort := cSettings.ServerSettings.Port
+	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
+	originalChallengePort := settings.CertSettings.HTTPChallengePort
+	originalConfigDir := settings.NginxSettings.ConfigDir
+
+	t.Cleanup(func() {
+		cSettings.ServerSettings.Port = originalPort
+		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
+		settings.CertSettings.HTTPChallengePort = originalChallengePort
+		settings.NginxSettings.ConfigDir = originalConfigDir
+	})
+
+	nginxConfigDir := t.TempDir()
+	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
+	if err := os.MkdirAll(sitesAvailableDir, 0755); err != nil {
+		t.Fatalf("failed to create sites-available dir: %v", err)
+	}
+
+	settings.NginxSettings.ConfigDir = nginxConfigDir
+	cSettings.ServerSettings.Port = 9000
+	cSettings.ServerSettings.EnableHTTPS = false
+	settings.CertSettings.HTTPChallengePort = "9180"
+
+	// Regression guard for Raw-field fidelity: the lua block contains both a
+	// statement-terminator (;) and a nested {} literal that could trip a naive
+	// dumper or scanner. The whole block must round-trip intact through Raw.
+	p := parser.NewStringParser(`server {
+    listen 443 ssl;
+    server_name example.com;
+    ssl_certificate_by_lua_block {
+        local opts = { ttl = 3600 }
+        ngx.log(ngx.INFO, "ttl=" .. opts.ttl .. "; ok")
+    }
+}`, parser.WithSkipValidDirectivesErr())
+
+	conf, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	content := createMaintenanceConfig(conf, sitesAvailableDir)
+
+	// Token-level invariants. The gonginx dumper may normalize whitespace inside
+	// the lua block, so assert on tokens that must survive verbatim instead of
+	// matching the exact source layout:
+	//   - the lua-string semicolon "; ok" must NOT be treated as a directive
+	//     terminator;
+	//   - the nested lua table braces must NOT collapse the outer directive.
+	for _, expected := range []string{
+		"ssl_certificate_by_lua_block",
+		`"; ok"`,
+		"ttl = 3600",
+	} {
+		if !strings.Contains(content, expected) {
+			t.Fatalf("maintenance config = %q, want lua block fragment %q preserved", content, expected)
+		}
+	}
+
+	// The outer block must still parse as a single nginx directive. If the lua
+	// `{ ttl = 3600 }` were misread as nested nginx blocks we would see more
+	// than one opening of the directive.
+	if got := strings.Count(content, "ssl_certificate_by_lua_block {"); got != 1 {
+		t.Fatalf("maintenance config = %q, want exactly one ssl_certificate_by_lua_block opener, got %d", content, got)
+	}
+}
+
+func TestCreateMaintenanceConfig_PreservesQuotedTLSDirectiveParams(t *testing.T) {
+	originalPort := cSettings.ServerSettings.Port
+	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
+	originalChallengePort := settings.CertSettings.HTTPChallengePort
+	originalConfigDir := settings.NginxSettings.ConfigDir
+
+	t.Cleanup(func() {
+		cSettings.ServerSettings.Port = originalPort
+		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
+		settings.CertSettings.HTTPChallengePort = originalChallengePort
+		settings.NginxSettings.ConfigDir = originalConfigDir
+	})
+
+	nginxConfigDir := t.TempDir()
+	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
+	if err := os.MkdirAll(sitesAvailableDir, 0755); err != nil {
+		t.Fatalf("failed to create sites-available dir: %v", err)
+	}
+
+	settings.NginxSettings.ConfigDir = nginxConfigDir
+	cSettings.ServerSettings.Port = 9000
+	cSettings.ServerSettings.EnableHTTPS = false
+	settings.CertSettings.HTTPChallengePort = "9180"
+
+	p := parser.NewStringParser(`server {
+    listen 443 ssl;
+    server_name example.com;
+    ssl_certificate "/etc/nginx/certs/example cert.pem";
+    ssl_certificate_key "/etc/nginx/certs/example key.pem";
+}`, parser.WithSkipValidDirectivesErr())
+
+	conf, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	content := createMaintenanceConfig(conf, sitesAvailableDir)
+	for _, expected := range []string{
+		`ssl_certificate "/etc/nginx/certs/example cert.pem";`,
+		`ssl_certificate_key "/etc/nginx/certs/example key.pem";`,
+	} {
+		if !strings.Contains(content, expected) {
+			t.Fatalf("maintenance config = %q, want quoted TLS directive %q", content, expected)
+		}
+	}
+}
+
+func TestCreateMaintenanceConfig_ExpandsWildcardTLSIncludesInSortedOrder(t *testing.T) {
+	originalPort := cSettings.ServerSettings.Port
+	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
+	originalChallengePort := settings.CertSettings.HTTPChallengePort
+	originalConfigDir := settings.NginxSettings.ConfigDir
+
+	t.Cleanup(func() {
+		cSettings.ServerSettings.Port = originalPort
+		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
+		settings.CertSettings.HTTPChallengePort = originalChallengePort
+		settings.NginxSettings.ConfigDir = originalConfigDir
+	})
+
+	nginxConfigDir := t.TempDir()
+	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
+	tlsDir := filepath.Join(nginxConfigDir, "snippets", "tls")
+	if err := os.MkdirAll(sitesAvailableDir, 0755); err != nil {
+		t.Fatalf("failed to create sites-available dir: %v", err)
+	}
+	if err := os.MkdirAll(tlsDir, 0755); err != nil {
+		t.Fatalf("failed to create tls dir: %v", err)
+	}
+
+	files := map[string]string{
+		"b.conf": "ssl_ciphers HIGH:!aNULL:!MD5;\n",
+		"a.conf": "ssl_protocols TLSv1.2 TLSv1.3;\n",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(tlsDir, name), []byte(content), 0644); err != nil {
+			t.Fatalf("failed to write %s: %v", name, err)
+		}
+	}
+
+	settings.NginxSettings.ConfigDir = nginxConfigDir
+	cSettings.ServerSettings.Port = 9000
+	cSettings.ServerSettings.EnableHTTPS = false
+	settings.CertSettings.HTTPChallengePort = "9180"
+
+	p := parser.NewStringParser(`server {
+    listen 443 ssl;
+    server_name example.com;
+    include snippets/tls/*.conf;
+    ssl_certificate /cert.pem;
+    ssl_certificate_key /key.pem;
+}`, parser.WithSkipValidDirectivesErr())
+
+	conf, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	content := createMaintenanceConfig(conf, sitesAvailableDir)
+
+	protocolsIndex := strings.Index(content, "ssl_protocols TLSv1.2 TLSv1.3;")
+	ciphersIndex := strings.Index(content, "ssl_ciphers HIGH:!aNULL:!MD5;")
+	if protocolsIndex == -1 || ciphersIndex == -1 {
+		t.Fatalf("maintenance config = %q, want wildcard TLS directives", content)
+	}
+	if protocolsIndex > ciphersIndex {
+		t.Fatalf("maintenance config = %q, want wildcard files expanded in sorted order", content)
+	}
+	if strings.Contains(content, "include snippets/tls/*.conf;") {
+		t.Fatalf("maintenance config = %q, want wildcard include omitted", content)
+	}
+}
+
+func TestCreateMaintenanceConfig_SkipsWildcardIncludesOutsideNginxConfigDir(t *testing.T) {
+	originalPort := cSettings.ServerSettings.Port
+	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
+	originalChallengePort := settings.CertSettings.HTTPChallengePort
+	originalConfigDir := settings.NginxSettings.ConfigDir
+
+	t.Cleanup(func() {
+		cSettings.ServerSettings.Port = originalPort
+		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
+		settings.CertSettings.HTTPChallengePort = originalChallengePort
+		settings.NginxSettings.ConfigDir = originalConfigDir
+	})
+
+	nginxConfigDir := t.TempDir()
+	outsideDir := t.TempDir()
+	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
+	if err := os.MkdirAll(sitesAvailableDir, 0755); err != nil {
+		t.Fatalf("failed to create sites-available dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outsideDir, "ssl.conf"), []byte("ssl_ciphers HIGH;\n"), 0644); err != nil {
+		t.Fatalf("failed to write outside include: %v", err)
+	}
+
+	settings.NginxSettings.ConfigDir = nginxConfigDir
+	cSettings.ServerSettings.Port = 9000
+	cSettings.ServerSettings.EnableHTTPS = false
+	settings.CertSettings.HTTPChallengePort = "9180"
+
+	p := parser.NewStringParser(fmt.Sprintf(`server {
+    listen 443 ssl;
+    server_name example.com;
+    include %s;
+    ssl_certificate /cert.pem;
+    ssl_certificate_key /key.pem;
+}`, filepath.ToSlash(filepath.Join(outsideDir, "*.conf"))), parser.WithSkipValidDirectivesErr())
+
+	conf, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	content := createMaintenanceConfig(conf, sitesAvailableDir)
+	if strings.Contains(content, "ssl_ciphers HIGH;") {
+		t.Fatalf("maintenance config = %q, want to skip wildcard outside nginx config dir", content)
+	}
+}
+
+func TestCreateMaintenanceConfig_LimitsWildcardIncludeMatches(t *testing.T) {
+	originalPort := cSettings.ServerSettings.Port
+	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
+	originalChallengePort := settings.CertSettings.HTTPChallengePort
+	originalConfigDir := settings.NginxSettings.ConfigDir
+
+	t.Cleanup(func() {
+		cSettings.ServerSettings.Port = originalPort
+		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
+		settings.CertSettings.HTTPChallengePort = originalChallengePort
+		settings.NginxSettings.ConfigDir = originalConfigDir
+	})
+
+	nginxConfigDir := t.TempDir()
+	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
+	tlsDir := filepath.Join(nginxConfigDir, "snippets", "tls")
+	if err := os.MkdirAll(sitesAvailableDir, 0755); err != nil {
+		t.Fatalf("failed to create sites-available dir: %v", err)
+	}
+	if err := os.MkdirAll(tlsDir, 0755); err != nil {
+		t.Fatalf("failed to create tls dir: %v", err)
+	}
+
+	for i := 0; i < maintenanceMaxWildcardMatches+1; i++ {
+		name := fmt.Sprintf("%02d.conf", i)
+		content := fmt.Sprintf("ssl_conf_command Options%d Value%d;\n", i, i)
+		if err := os.WriteFile(filepath.Join(tlsDir, name), []byte(content), 0644); err != nil {
+			t.Fatalf("failed to write %s: %v", name, err)
+		}
+	}
+
+	settings.NginxSettings.ConfigDir = nginxConfigDir
+	cSettings.ServerSettings.Port = 9000
+	cSettings.ServerSettings.EnableHTTPS = false
+	settings.CertSettings.HTTPChallengePort = "9180"
+
+	p := parser.NewStringParser(`server {
+    listen 443 ssl;
+    server_name example.com;
+    include snippets/tls/*.conf;
+    ssl_certificate /cert.pem;
+    ssl_certificate_key /key.pem;
+}`, parser.WithSkipValidDirectivesErr())
+
+	conf, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	content := createMaintenanceConfig(conf, sitesAvailableDir)
+	if !strings.Contains(content, "ssl_conf_command Options31 Value31;") {
+		t.Fatalf("maintenance config = %q, want last allowed wildcard match", content)
+	}
+	if strings.Contains(content, "ssl_conf_command Options32 Value32;") {
+		t.Fatalf("maintenance config = %q, want wildcard matches capped at %d", content, maintenanceMaxWildcardMatches)
+	}
+}
+
+func TestCreateMaintenanceConfig_LimitsWildcardIncludeMatchesAfterFiltering(t *testing.T) {
+	originalPort := cSettings.ServerSettings.Port
+	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
+	originalChallengePort := settings.CertSettings.HTTPChallengePort
+	originalConfigDir := settings.NginxSettings.ConfigDir
+
+	t.Cleanup(func() {
+		cSettings.ServerSettings.Port = originalPort
+		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
+		settings.CertSettings.HTTPChallengePort = originalChallengePort
+		settings.NginxSettings.ConfigDir = originalConfigDir
+	})
+
+	nginxConfigDir := t.TempDir()
+	outsideDir := t.TempDir()
+	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
+	tlsDir := filepath.Join(nginxConfigDir, "snippets", "tls")
+	if err := os.MkdirAll(sitesAvailableDir, 0755); err != nil {
+		t.Fatalf("failed to create sites-available dir: %v", err)
+	}
+	if err := os.MkdirAll(tlsDir, 0755); err != nil {
+		t.Fatalf("failed to create tls dir: %v", err)
+	}
+
+	outsideFile := filepath.Join(outsideDir, "outside.conf")
+	if err := os.WriteFile(outsideFile, []byte("ssl_ciphers EVIL;\n"), 0644); err != nil {
+		t.Fatalf("failed to write outside file: %v", err)
+	}
+	for i := 0; i < maintenanceMaxWildcardMatches; i++ {
+		linkPath := filepath.Join(tlsDir, fmt.Sprintf("%02d-escape.conf", i))
+		if err := os.Symlink(outsideFile, linkPath); err != nil {
+			t.Skipf("symlink creation is not available in this environment: %v", err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(tlsDir, "zz-real.conf"), []byte("ssl_protocols TLSv1.2 TLSv1.3;\n"), 0644); err != nil {
+		t.Fatalf("failed to write legal wildcard include: %v", err)
+	}
+
+	settings.NginxSettings.ConfigDir = nginxConfigDir
+	cSettings.ServerSettings.Port = 9000
+	cSettings.ServerSettings.EnableHTTPS = false
+	settings.CertSettings.HTTPChallengePort = "9180"
+
+	p := parser.NewStringParser(`server {
+    listen 443 ssl;
+    server_name example.com;
+    include snippets/tls/*.conf;
+    ssl_certificate /cert.pem;
+    ssl_certificate_key /key.pem;
+}`, parser.WithSkipValidDirectivesErr())
+
+	conf, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	content := createMaintenanceConfig(conf, sitesAvailableDir)
+	if !strings.Contains(content, "ssl_protocols TLSv1.2 TLSv1.3;") {
+		t.Fatalf("maintenance config = %q, want legal wildcard match after filtering invalid matches", content)
+	}
+	if strings.Contains(content, "ssl_ciphers EVIL;") {
+		t.Fatalf("maintenance config = %q, want symlink escape still filtered", content)
+	}
+}
+
+func TestCreateMaintenanceConfig_RejectsWildcardSymlinkEscape(t *testing.T) {
+	originalPort := cSettings.ServerSettings.Port
+	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
+	originalChallengePort := settings.CertSettings.HTTPChallengePort
+	originalConfigDir := settings.NginxSettings.ConfigDir
+
+	t.Cleanup(func() {
+		cSettings.ServerSettings.Port = originalPort
+		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
+		settings.CertSettings.HTTPChallengePort = originalChallengePort
+		settings.NginxSettings.ConfigDir = originalConfigDir
+	})
+
+	nginxConfigDir := t.TempDir()
+	outsideDir := t.TempDir()
+	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
+	tlsDir := filepath.Join(nginxConfigDir, "snippets", "tls")
+	if err := os.MkdirAll(sitesAvailableDir, 0755); err != nil {
+		t.Fatalf("failed to create sites-available dir: %v", err)
+	}
+	if err := os.MkdirAll(tlsDir, 0755); err != nil {
+		t.Fatalf("failed to create tls dir: %v", err)
+	}
+	outsideFile := filepath.Join(outsideDir, "evil.conf")
+	if err := os.WriteFile(outsideFile, []byte("ssl_ciphers EVIL;\n"), 0644); err != nil {
+		t.Fatalf("failed to write outside file: %v", err)
+	}
+	linkPath := filepath.Join(tlsDir, "ssl-escape.conf")
+	if err := os.Symlink(outsideFile, linkPath); err != nil {
+		t.Skipf("symlink creation is not available in this environment: %v", err)
+	}
+
+	settings.NginxSettings.ConfigDir = nginxConfigDir
+	cSettings.ServerSettings.Port = 9000
+	cSettings.ServerSettings.EnableHTTPS = false
+	settings.CertSettings.HTTPChallengePort = "9180"
+
+	p := parser.NewStringParser(`server {
+    listen 443 ssl;
+    server_name example.com;
+    include snippets/tls/*.conf;
+    ssl_certificate /cert.pem;
+    ssl_certificate_key /key.pem;
+}`, parser.WithSkipValidDirectivesErr())
+
+	conf, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	content := createMaintenanceConfig(conf, sitesAvailableDir)
+	if strings.Contains(content, "ssl_ciphers EVIL;") {
+		t.Fatalf("maintenance config = %q, want to reject wildcard symlink escape", content)
+	}
+}
+
+func TestMaintenanceIncludeExpander_AllowsCertbotOptionsPath(t *testing.T) {
+	originalConfigDir := settings.NginxSettings.ConfigDir
+	originalCertbotPath := certbotNginxTLSOptionsPath
+	t.Cleanup(func() {
+		settings.NginxSettings.ConfigDir = originalConfigDir
+		certbotNginxTLSOptionsPath = originalCertbotPath
+	})
+
+	settings.NginxSettings.ConfigDir = t.TempDir()
+	certbotDir := t.TempDir()
+	certbotNginxTLSOptionsPath = filepath.Join(certbotDir, "options-ssl-nginx.conf")
+	if err := os.WriteFile(certbotNginxTLSOptionsPath, []byte("ssl_protocols TLSv1.3;\n"), 0644); err != nil {
+		t.Fatalf("failed to write certbot options path: %v", err)
+	}
+
+	expander := newMaintenanceIncludeExpander("")
+
+	if !expander.isAllowedSingleInclude(certbotNginxTLSOptionsPath) {
+		t.Fatalf("expected certbot options path %q to be allowed", certbotNginxTLSOptionsPath)
+	}
+
+	if expander.isAllowedSingleInclude("/etc/letsencrypt/other.conf") {
+		t.Fatalf("expected unrelated path under /etc/letsencrypt to be rejected")
+	}
+
+	if expander.isAllowedSingleInclude("/etc/passwd") {
+		t.Fatalf("expected arbitrary system path to be rejected")
+	}
+}
+
+func TestMaintenanceIncludeExpander_RejectsCertbotOptionsSymlink(t *testing.T) {
+	originalConfigDir := settings.NginxSettings.ConfigDir
+	originalCertbotPath := certbotNginxTLSOptionsPath
+	t.Cleanup(func() {
+		settings.NginxSettings.ConfigDir = originalConfigDir
+		certbotNginxTLSOptionsPath = originalCertbotPath
+	})
+
+	settings.NginxSettings.ConfigDir = t.TempDir()
+	certbotDir := t.TempDir()
+	outsideDir := t.TempDir()
+	certbotNginxTLSOptionsPath = filepath.Join(certbotDir, "options-ssl-nginx.conf")
+	outsideFile := filepath.Join(outsideDir, "outside.conf")
+	if err := os.WriteFile(outsideFile, []byte("ssl_ciphers EVIL;\n"), 0644); err != nil {
+		t.Fatalf("failed to write outside file: %v", err)
+	}
+	if err := os.Symlink(outsideFile, certbotNginxTLSOptionsPath); err != nil {
+		t.Skipf("symlink creation is not available in this environment: %v", err)
+	}
+
+	expander := newMaintenanceIncludeExpander("")
+	if expander.isAllowedSingleInclude(certbotNginxTLSOptionsPath) {
+		t.Fatalf("expected certbot options symlink to be rejected")
+	}
+}
+
+func TestCreateMaintenanceConfig_EnforcesIncludeDepthLimit(t *testing.T) {
+	originalPort := cSettings.ServerSettings.Port
+	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
+	originalChallengePort := settings.CertSettings.HTTPChallengePort
+	originalConfigDir := settings.NginxSettings.ConfigDir
+
+	t.Cleanup(func() {
+		cSettings.ServerSettings.Port = originalPort
+		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
+		settings.CertSettings.HTTPChallengePort = originalChallengePort
+		settings.NginxSettings.ConfigDir = originalConfigDir
+	})
+
+	nginxConfigDir := t.TempDir()
+	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
+	snippetsDir := filepath.Join(nginxConfigDir, "snippets")
+	if err := os.MkdirAll(sitesAvailableDir, 0755); err != nil {
+		t.Fatalf("failed to create sites-available dir: %v", err)
+	}
+	if err := os.MkdirAll(snippetsDir, 0755); err != nil {
+		t.Fatalf("failed to create snippets dir: %v", err)
+	}
+
+	// Build a chain s1 -> s2 -> ... -> s7, each carrying a unique ssl_conf_command.
+	// Top-level include into s1 starts at depth 1, so the chain must exceed
+	// maintenanceMaxIncludeDepth + 1 levels to ensure the last link is dropped.
+	chainLen := maintenanceMaxIncludeDepth + 2
+	for i := 1; i <= chainLen; i++ {
+		var body strings.Builder
+		body.WriteString(fmt.Sprintf("ssl_conf_command Level%d Value%d;\n", i, i))
+		if i < chainLen {
+			body.WriteString(fmt.Sprintf("include s%d.conf;\n", i+1))
+		}
+		path := filepath.Join(snippetsDir, fmt.Sprintf("s%d.conf", i))
+		if err := os.WriteFile(path, []byte(body.String()), 0644); err != nil {
+			t.Fatalf("failed to write %s: %v", path, err)
+		}
+	}
+
+	settings.NginxSettings.ConfigDir = nginxConfigDir
+	cSettings.ServerSettings.Port = 9000
+	cSettings.ServerSettings.EnableHTTPS = false
+	settings.CertSettings.HTTPChallengePort = "9180"
+
+	p := parser.NewStringParser(`server {
+    listen 443 ssl;
+    server_name example.com;
+    include snippets/s1.conf;
+    ssl_certificate /cert.pem;
+    ssl_certificate_key /key.pem;
+}`, parser.WithSkipValidDirectivesErr())
+
+	conf, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	content := createMaintenanceConfig(conf, sitesAvailableDir)
+
+	// Levels 1..maintenanceMaxIncludeDepth must be present.
+	for i := 1; i <= maintenanceMaxIncludeDepth; i++ {
+		expected := fmt.Sprintf("ssl_conf_command Level%d Value%d;", i, i)
+		if !strings.Contains(content, expected) {
+			t.Fatalf("maintenance config = %q, want directive from depth %d (%q)", content, i, expected)
+		}
+	}
+
+	// Anything beyond the depth limit must be dropped.
+	for i := maintenanceMaxIncludeDepth + 1; i <= chainLen; i++ {
+		unexpected := fmt.Sprintf("ssl_conf_command Level%d Value%d;", i, i)
+		if strings.Contains(content, unexpected) {
+			t.Fatalf("maintenance config = %q, want directive at depth %d to be dropped (%q)", content, i, unexpected)
+		}
+	}
+}
+
+func TestCreateMaintenanceConfig_AcceptsAbsoluteIncludeInsideConfigDir(t *testing.T) {
+	originalPort := cSettings.ServerSettings.Port
+	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
+	originalChallengePort := settings.CertSettings.HTTPChallengePort
+	originalConfigDir := settings.NginxSettings.ConfigDir
+
+	t.Cleanup(func() {
+		cSettings.ServerSettings.Port = originalPort
+		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
+		settings.CertSettings.HTTPChallengePort = originalChallengePort
+		settings.NginxSettings.ConfigDir = originalConfigDir
+	})
+
+	nginxConfigDir := t.TempDir()
+	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
+	snippetsDir := filepath.Join(nginxConfigDir, "snippets")
+	if err := os.MkdirAll(sitesAvailableDir, 0755); err != nil {
+		t.Fatalf("failed to create sites-available dir: %v", err)
+	}
+	if err := os.MkdirAll(snippetsDir, 0755); err != nil {
+		t.Fatalf("failed to create snippets dir: %v", err)
+	}
+
+	absoluteInclude := filepath.Join(snippetsDir, "absolute-ssl.conf")
+	if err := os.WriteFile(absoluteInclude, []byte("ssl_protocols TLSv1.3;\n"), 0644); err != nil {
+		t.Fatalf("failed to write absolute include: %v", err)
+	}
+
+	settings.NginxSettings.ConfigDir = nginxConfigDir
+	cSettings.ServerSettings.Port = 9000
+	cSettings.ServerSettings.EnableHTTPS = false
+	settings.CertSettings.HTTPChallengePort = "9180"
+
+	p := parser.NewStringParser(fmt.Sprintf(`server {
+    listen 443 ssl;
+    server_name example.com;
+    include %s;
+    ssl_certificate /cert.pem;
+    ssl_certificate_key /key.pem;
+}`, filepath.ToSlash(absoluteInclude)), parser.WithSkipValidDirectivesErr())
+
+	conf, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	content := createMaintenanceConfig(conf, sitesAvailableDir)
+
+	if !strings.Contains(content, "ssl_protocols TLSv1.3;") {
+		t.Fatalf("maintenance config = %q, want directive from absolute include under config dir", content)
+	}
+	if strings.Contains(content, "include "+filepath.ToSlash(absoluteInclude)) {
+		t.Fatalf("maintenance config = %q, want absolute include directive itself to be omitted", content)
+	}
+}
+
+func TestCreateMaintenanceConfig_IsolatesIncludeExpansionPerServer(t *testing.T) {
+	originalPort := cSettings.ServerSettings.Port
+	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
+	originalChallengePort := settings.CertSettings.HTTPChallengePort
+	originalConfigDir := settings.NginxSettings.ConfigDir
+
+	t.Cleanup(func() {
+		cSettings.ServerSettings.Port = originalPort
+		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
+		settings.CertSettings.HTTPChallengePort = originalChallengePort
+		settings.NginxSettings.ConfigDir = originalConfigDir
+	})
+
+	nginxConfigDir := t.TempDir()
+	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
+	snippetsDir := filepath.Join(nginxConfigDir, "snippets")
+	if err := os.MkdirAll(sitesAvailableDir, 0755); err != nil {
+		t.Fatalf("failed to create sites-available dir: %v", err)
+	}
+	if err := os.MkdirAll(snippetsDir, 0755); err != nil {
+		t.Fatalf("failed to create snippets dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(snippetsDir, "shared-ssl.conf"), []byte("ssl_protocols TLSv1.3;\n"), 0644); err != nil {
+		t.Fatalf("failed to write shared include: %v", err)
+	}
+
+	settings.NginxSettings.ConfigDir = nginxConfigDir
+	cSettings.ServerSettings.Port = 9000
+	cSettings.ServerSettings.EnableHTTPS = false
+	settings.CertSettings.HTTPChallengePort = "9180"
+
+	p := parser.NewStringParser(`server {
+    listen 443 ssl;
+    server_name a.example.com;
+    include snippets/shared-ssl.conf;
+    ssl_certificate /cert-a.pem;
+    ssl_certificate_key /key-a.pem;
+}
+server {
+    listen 443 ssl;
+    server_name b.example.com;
+    include snippets/shared-ssl.conf;
+    ssl_certificate /cert-b.pem;
+    ssl_certificate_key /key-b.pem;
+}`, parser.WithSkipValidDirectivesErr())
+
+	conf, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	content := createMaintenanceConfig(conf, sitesAvailableDir)
+
+	// The shared include must appear in both generated server blocks, proving
+	// the visited cache does not leak across server-block expansions.
+	if strings.Count(content, "ssl_protocols TLSv1.3;") != 2 {
+		t.Fatalf("maintenance config = %q, want shared TLS directive expanded once per server block", content)
+	}
+	if !strings.Contains(content, "server_name a.example.com;") || !strings.Contains(content, "server_name b.example.com;") {
+		t.Fatalf("maintenance config = %q, want both server_name directives preserved", content)
 	}
 }

--- a/internal/site/maintenance_test.go
+++ b/internal/site/maintenance_test.go
@@ -822,6 +822,131 @@ func TestMaintenanceIncludeExpander_RejectsCertbotOptionsSymlink(t *testing.T) {
 	}
 }
 
+func TestMaintenanceIncludeExpander_UsesBaseDirUnderConfigDir(t *testing.T) {
+	originalConfigDir := settings.NginxSettings.ConfigDir
+	t.Cleanup(func() {
+		settings.NginxSettings.ConfigDir = originalConfigDir
+	})
+
+	nginxConfigDir := t.TempDir()
+	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
+	if err := os.MkdirAll(sitesAvailableDir, 0755); err != nil {
+		t.Fatalf("failed to create sites-available dir: %v", err)
+	}
+
+	settings.NginxSettings.ConfigDir = nginxConfigDir
+	expander := newMaintenanceIncludeExpander(sitesAvailableDir)
+
+	if expander.baseDir != filepath.Clean(sitesAvailableDir) {
+		t.Fatalf("baseDir = %q, want %q", expander.baseDir, filepath.Clean(sitesAvailableDir))
+	}
+}
+
+func TestMaintenanceIncludeExpander_FallsBackWhenBaseDirEscapesConfigDir(t *testing.T) {
+	originalConfigDir := settings.NginxSettings.ConfigDir
+	t.Cleanup(func() {
+		settings.NginxSettings.ConfigDir = originalConfigDir
+	})
+
+	nginxConfigDir := t.TempDir()
+	outsideDir := t.TempDir()
+	settings.NginxSettings.ConfigDir = nginxConfigDir
+
+	expander := newMaintenanceIncludeExpander(outsideDir)
+
+	if expander.baseDir != filepath.Clean(nginxConfigDir) {
+		t.Fatalf("baseDir = %q, want fallback to confDir %q", expander.baseDir, filepath.Clean(nginxConfigDir))
+	}
+}
+
+func TestMaintenanceIncludeExpander_ResolveIncludePathSkipsExistingRelativeEscape(t *testing.T) {
+	originalConfigDir := settings.NginxSettings.ConfigDir
+	t.Cleanup(func() {
+		settings.NginxSettings.ConfigDir = originalConfigDir
+	})
+
+	nginxConfigDir := t.TempDir()
+	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
+	outsideDir := t.TempDir()
+	if err := os.MkdirAll(sitesAvailableDir, 0755); err != nil {
+		t.Fatalf("failed to create sites-available dir: %v", err)
+	}
+	outsideFile := filepath.Join(outsideDir, "ssl.conf")
+	if err := os.WriteFile(outsideFile, []byte("ssl_ciphers EVIL;\n"), 0644); err != nil {
+		t.Fatalf("failed to write outside file: %v", err)
+	}
+
+	settings.NginxSettings.ConfigDir = nginxConfigDir
+	expander := newMaintenanceIncludeExpander(sitesAvailableDir)
+	includePath, err := filepath.Rel(sitesAvailableDir, outsideFile)
+	if err != nil {
+		t.Fatalf("failed to build relative escape include path: %v", err)
+	}
+
+	resolvedPath := expander.resolveIncludePath(includePath)
+	if filepath.Clean(resolvedPath) == filepath.Clean(outsideFile) {
+		t.Fatalf("resolveIncludePath(%q) = %q, want existing path outside nginx config dir ignored", includePath, resolvedPath)
+	}
+}
+
+func TestMaintenanceIncludeExpander_ResolveIncludePathFallsBackToConfDirOnEscape(t *testing.T) {
+	originalConfigDir := settings.NginxSettings.ConfigDir
+	t.Cleanup(func() {
+		settings.NginxSettings.ConfigDir = originalConfigDir
+	})
+
+	nginxConfigDir := t.TempDir()
+	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")
+	if err := os.MkdirAll(sitesAvailableDir, 0755); err != nil {
+		t.Fatalf("failed to create sites-available dir: %v", err)
+	}
+
+	settings.NginxSettings.ConfigDir = nginxConfigDir
+	expander := newMaintenanceIncludeExpander(sitesAvailableDir)
+
+	resolvedPath := expander.resolveIncludePath(filepath.Join("..", "..", "escape.conf"))
+	if resolvedPath != filepath.Clean(nginxConfigDir) {
+		t.Fatalf("resolveIncludePath escape fallback = %q, want confDir %q", resolvedPath, filepath.Clean(nginxConfigDir))
+	}
+}
+
+func TestMaintenanceIncludeExpander_ResolveWildcardIncludePathRejectsAbsoluteEscape(t *testing.T) {
+	originalConfigDir := settings.NginxSettings.ConfigDir
+	t.Cleanup(func() {
+		settings.NginxSettings.ConfigDir = originalConfigDir
+	})
+
+	nginxConfigDir := t.TempDir()
+	outsideDir := t.TempDir()
+	settings.NginxSettings.ConfigDir = nginxConfigDir
+	expander := newMaintenanceIncludeExpander("")
+
+	outsidePattern := filepath.Join(outsideDir, "*.conf")
+	resolvedPath := expander.resolveWildcardIncludePath(outsidePattern)
+	if filepath.Clean(resolvedPath) == filepath.Clean(outsidePattern) {
+		t.Fatalf("resolveWildcardIncludePath(%q) = %q, want absolute path outside nginx config dir rejected", outsidePattern, resolvedPath)
+	}
+}
+
+func TestMaintenanceIncludeExpander_ExtractIncludeFileRejectsDisallowedPath(t *testing.T) {
+	originalConfigDir := settings.NginxSettings.ConfigDir
+	t.Cleanup(func() {
+		settings.NginxSettings.ConfigDir = originalConfigDir
+	})
+
+	settings.NginxSettings.ConfigDir = t.TempDir()
+	outsideDir := t.TempDir()
+	outsideFile := filepath.Join(outsideDir, "ssl.conf")
+	if err := os.WriteFile(outsideFile, []byte("ssl_ciphers EVIL;\n"), 0644); err != nil {
+		t.Fatalf("failed to write outside include: %v", err)
+	}
+
+	expander := newMaintenanceIncludeExpander("")
+	if directives := expander.extractIncludeFile(outsideFile, 1); len(directives) != 0 {
+		t.Fatalf("extractIncludeFile(%q) returned %d directives, want disallowed path rejected", outsideFile, len(directives))
+	}
+}
+
 func TestCreateMaintenanceConfig_EnforcesIncludeDepthLimit(t *testing.T) {
 	originalPort := cSettings.ServerSettings.Port
 	originalHTTPS := cSettings.ServerSettings.EnableHTTPS


### PR DESCRIPTION
## Summary

- Fixes #1679 by preserving TLS handshake settings when generating maintenance-mode configs.
- Expand allowed TLS-related `include` files into concrete `ssl_*` directives instead of copying `include` directives verbatim.
- Preserve quoted TLS parameters and TLS block directives such as `ssl_certificate_by_lua_block`.
- Harden include expansion with allowlisting, depth limits, wildcard limits, and symlink escape checks.

## Background

Maintenance mode replaces the original site config with a generated server config that proxies requests to the NGINX UI maintenance page. For HTTPS sites, this generated config still needs enough TLS configuration to complete the TLS handshake.

In #1679, maintenance mode caused Cloudflare 525 SSL handshake failures after an OS upgrade. The affected setup needed specific TLS ciphers/options that worked in the normal site config, but the generated maintenance config did not reliably carry those TLS settings over.

Rather than making the maintenance template manually editable, this PR preserves the original site’s TLS handshake configuration automatically by expanding safe TLS include files into the generated maintenance config.

## Changes

- Preserve maintenance server identity directives:
  - `listen`
  - `server_name`
  - `http2`
- Preserve TLS handshake directives:
  - direct `ssl_*` directives from the original server block
  - `ssl_*` directives from allowed include files
  - quoted TLS directive params
  - TLS block directives, including Lua/OpenResty-style blocks
- Expand supported includes safely:
  - relative includes resolved from the site config directory
  - nested includes resolved from the current include file directory
  - wildcard includes under the NGINX config directory
  - certbot’s well-known `/etc/letsencrypt/options-ssl-nginx.conf` path when it is a regular file
- Harden include handling:
  - skip include files outside the NGINX config directory except the certbot allowlist path
  - reject wildcard symlink escapes
  - reject certbot allowlist symlinks
  - cap recursive include depth
  - cap wildcard expansion after filtering invalid matches
  - avoid leaking `listen`, `server_name`, and `http2` from included files into the maintenance server
- Add an internal-only raw directive path for preserving directive fidelity without exposing it through JSON APIs.

## Tests

Added regression tests for:

- TLS include expansion
- recursive include expansion and cycle handling
- nested relative wildcard includes
- wildcard sorting and match caps
- wildcard filtering before applying match limits
- include rejection outside the NGINX config directory
- wildcard symlink escape rejection
- certbot options path allowlist and symlink rejection
- TLS block directive preservation
- Lua block preservation with semicolons and nested braces
- quoted TLS directive parameter preservation
- per-server include expansion isolation
- internal-only `NgxDirective.Raw` JSON behavior

Verified with:

```bash
go test ./internal/site -run "TestCreateMaintenanceConfig|TestMaintenanceIncludeExpander" -count=1
go test ./internal/nginx -run "TestNgxDirectiveRawIsInternalOnly|Test.*BuildConfig|Test.*RootBlock|Test.*Ngx" -count=1