### PR TITLE
fix: accept redacted sentinel in IP whitelist round-trip

### DIFF
--- a/api/settings/settings.go
+++ b/api/settings/settings.go
@@ -18,7 +18,7 @@ import (
 	cSettings "github.com/uozi-tech/cosy/settings"
 )
 
-const redactedSensitiveValue = "__NGINX_UI_REDACTED__"
+const redactedSensitiveValue = settings.RedactedSensitiveValue
 
 var manuallyProtectedSettingGetters = map[string]func() any{
 	"app.jwt_secret": func() any {

--- a/api/settings/settings_test.go
+++ b/api/settings/settings_test.go
@@ -10,12 +10,22 @@ import (
 	"github.com/0xJacky/Nginx-UI/internal/cache"
 	"github.com/0xJacky/Nginx-UI/internal/middleware"
 	internaluser "github.com/0xJacky/Nginx-UI/internal/user"
+	"github.com/0xJacky/Nginx-UI/internal/validation"
 	"github.com/0xJacky/Nginx-UI/model"
 	appsettings "github.com/0xJacky/Nginx-UI/settings"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	cSettings "github.com/uozi-tech/cosy/settings"
 )
+
+// TestMain registers the custom gin binding validators used by settings.Auth
+// and settings.Cert. Production wires this via internal/kernel/boot.go, which
+// these package-level tests bypass.
+func TestMain(m *testing.M) {
+	gin.SetMode(gin.TestMode)
+	validation.Init()
+	m.Run()
+}
 
 func TestSaveSettingsRejectsNegativeLogrotateInterval(t *testing.T) {
 	gin.SetMode(gin.TestMode)
@@ -34,6 +44,32 @@ func TestSaveSettingsRejectsNegativeLogrotateInterval(t *testing.T) {
 
 	assert.Equal(t, http.StatusNotAcceptable, w.Code)
 	assert.Contains(t, w.Body.String(), "\"interval\":\"min\"")
+}
+
+// TestSaveSettingsAcceptsRedactedIPWhiteList reproduces the reported bug where the
+// frontend round-trips the sensitive-field placeholder `__NGINX_UI_REDACTED__` back
+// to POST /api/settings. Without the `redacted` validator composed via `ip|redacted`,
+// the payload fails binding on `auth.ip_white_list` with tag `ip`. With the fix, the
+// placeholder is accepted; other unrelated binding errors (here, negative
+// logrotate.interval) still fire, so the response is still 406 but must not mention
+// `ip_white_list`. This avoids exercising the success path, which would need a
+// fully initialized settings.Conf on disk.
+func TestSaveSettingsAcceptsRedactedIPWhiteList(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/settings",
+		bytes.NewBufferString(`{
+			"auth":{"ip_white_list":["__NGINX_UI_REDACTED__"],"ban_threshold_minutes":1,"max_attempts":1},
+			"cert":{"renewal_interval":7},
+			"logrotate":{"enabled":true,"interval":-1}
+		}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	SaveSettings(c)
+
+	assert.Equal(t, http.StatusNotAcceptable, w.Code)
+	assert.Contains(t, w.Body.String(), "\"interval\":\"min\"")
+	assert.NotContains(t, w.Body.String(), "ip_white_list")
 }
 
 func TestGetSettingsRedactsSensitiveFields(t *testing.T) {

--- a/internal/validation/redacted.go
+++ b/internal/validation/redacted.go
@@ -1,0 +1,10 @@
+package validation
+
+import (
+	"github.com/0xJacky/Nginx-UI/settings"
+	val "github.com/go-playground/validator/v10"
+)
+
+func redacted(fl val.FieldLevel) bool {
+	return fl.Field().String() == settings.RedactedSensitiveValue
+}

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -37,5 +37,8 @@ func Init() {
 		logger.Fatal(err)
 	}
 
-	return
+	err = v.RegisterValidation("redacted", redacted)
+	if err != nil {
+		logger.Fatal(err)
+	}
 }

--- a/settings/auth.go
+++ b/settings/auth.go
@@ -1,7 +1,7 @@
 package settings
 
 type Auth struct {
-	IPWhiteList         []string `json:"ip_white_list" binding:"omitempty,dive,ip" ini:",,allowshadow" protected:"true"`
+	IPWhiteList         []string `json:"ip_white_list" binding:"omitempty,dive,ip|redacted" ini:",,allowshadow" protected:"true"`
 	BanThresholdMinutes int      `json:"ban_threshold_minutes" binding:"min=1"`
 	MaxAttempts         int      `json:"max_attempts" binding:"min=1"`
 }

--- a/settings/redacted.go
+++ b/settings/redacted.go
@@ -1,0 +1,7 @@
+package settings
+
+// RedactedSensitiveValue is the sentinel string returned in place of
+// sensitive setting values (secrets, tokens, IP allow-list entries) by the
+// settings API. Payloads that echo it back are treated as "keep the current
+// value" rather than an actual user-supplied override.
+const RedactedSensitiveValue = "__NGINX_UI_REDACTED__"


### PR DESCRIPTION
## Summary

- `POST /api/settings` returned HTTP 406 whenever the frontend echoed back the redacted `auth.ip_white_list` payload (`["__NGINX_UI_REDACTED__"]`), because gin's `dive,ip` validator did not accept the sentinel. Every settings save was blocked.
- Introduce a generic `redacted` binding validator in `internal/validation/` (matches the canonical peer pattern, called from `internal/kernel/boot.go`), and compose it at the field via validator/v10's OR operator: `binding:"omitempty,dive,ip|redacted"`. Any future protected+validated field opts in by appending `|redacted` — no `X_or_redacted` proliferation.
- Promote the sentinel to `settings.RedactedSensitiveValue` so `internal/validation` can reference it without a layer-inverting import of `api/settings`.
- Add `TestMain` in `api/settings/settings_test.go` that calls `validation.Init()` (tests bypass `internal/kernel/boot.go` where production wires the custom validators) and a regression test `TestSaveSettingsAcceptsRedactedIPWhiteList`.

## Test plan

- [x] `go vet ./api/settings/... ./settings/... ./internal/validation/... ./internal/kernel/...` — clean
- [x] `go test ./api/settings/ -race -run "TestSaveSettings|TestGetSettingsRedactsSensitiveFields|TestRestoreRedactedSensitiveSettings"` — all 4 relevant tests PASS
- [x] `gofmt -l` on touched files — empty
- [ ] Manual E2E: load "Preferences" page in the UI, click Save without editing any field, complete 2FA — should see "Save successfully" (no more 406).
- [ ] Manual negative: POST with an invalid IP (e.g. `"999.999.999.999"`) still returns 406 with `ip_white_list` error.