### PR TITLE
fix(preference): handle unhandled promise rejections on save

### DIFF
--- a/app/src/views/preference/store/index.ts
+++ b/app/src/views/preference/store/index.ts
@@ -1,10 +1,11 @@
 import type { Settings } from '@/api/settings'
 import settings from '@/api/settings'
 import { use2FAModal } from '@/components/TwoFA'
+import { useGlobalApp } from '@/composables/useGlobalApp'
 import { useSettingsStore } from '@/pinia'
 
 const useSystemSettingsStore = defineStore('systemSettings', () => {
-  const { message } = App.useApp()
+  const { message } = useGlobalApp()
 
   const data = ref<Settings>({
     app: {
@@ -112,6 +113,8 @@ const useSystemSettingsStore = defineStore('systemSettings', () => {
     settings.get().then(r => {
       r.cert.recursive_nameservers ||= []
       data.value = r
+    }).catch(err => {
+      console.error('Failed to load settings:', err)
     })
   }
 
@@ -127,18 +130,30 @@ const useSystemSettingsStore = defineStore('systemSettings', () => {
 
     const otpModal = use2FAModal()
 
-    otpModal.open().then(() => {
-      settings.save(data.value!).then(r => {
-        const settingsStore = useSettingsStore()
-        const { server_name } = storeToRefs(settingsStore)
-        if (!settingsStore.is_remote)
-          server_name.value = r?.server?.name ?? ''
-        r.cert.recursive_nameservers ||= []
-        data.value = r
-        message.success($gettext('Save successfully'))
-        errors.value = {}
-      })
-    })
+    try {
+      await otpModal.open()
+    }
+    catch {
+      // User cancelled 2FA or the preflight check failed — abort save silently
+      return
+    }
+
+    try {
+      const r = await settings.save(data.value!)
+      const settingsStore = useSettingsStore()
+      const { server_name } = storeToRefs(settingsStore)
+      if (!settingsStore.is_remote)
+        server_name.value = r?.server?.name ?? ''
+      r.cert.recursive_nameservers ||= []
+      data.value = r
+      message.success($gettext('Save successfully'))
+      errors.value = {}
+    }
+    catch (err) {
+      // The HTTP interceptor already surfaces the error via handleApiError,
+      // so we only log here to avoid a duplicate toast.
+      console.error('Failed to save settings:', err)
+    }
   }
 
   return { data, errors, getSettings, save }


### PR DESCRIPTION
## Summary

Save on the Preference page threw `Uncaught (in promise) TypeError: e.success is not a function`
because the store used bare `.then()` chains without error handling, and the deprecated `App.useApp()`
lacks a fallback for the message API.

## Changes

- Replace deprecated `App.useApp()` with project-standard `useGlobalApp()` for message API
- Rewrite `save()` with `async/await` + `try/catch` for both 2FA and API call
- Add `.catch()` to `getSettings()` for consistent error handling

## Validation

- [x] Open Preference page, click Save without 2FA — "Save successfully"
- [x] Open Preference page with 2FA enabled, enter correct OTP — "Save successfully"
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean