### PR TITLE
feat(i18n): auto-detect browser language on first visit and add Ukrainian dayjs locale

### DIFF
--- a/app/src/components/SetLanguage/SetLanguage.vue
+++ b/app/src/components/SetLanguage/SetLanguage.vue
@@ -55,6 +55,7 @@ const localeMap: Record<string, string> = {
   ru: 'ru',
   tr: 'tr',
   vi: 'vi',
+  uk_UA: 'uk',
 }
 
 // Predefined locale importers for dynamic loading
@@ -73,6 +74,7 @@ const localeImporters = {
   'ru': () => import('dayjs/locale/ru'),
   'tr': () => import('dayjs/locale/tr'),
   'vi': () => import('dayjs/locale/vi'),
+  'uk': () => import('dayjs/locale/uk'),
 }
 
 // Dynamically load dayjs locale files

--- a/app/src/lib/helper/i18n.ts
+++ b/app/src/lib/helper/i18n.ts
@@ -1,0 +1,93 @@
+import i18n from '../../../i18n.json'
+
+// Mapping from BCP-47 language tags to supported project language codes
+const LOCALE_MAP: Record<string, string> = {
+  // Chinese variants
+  'zh': 'zh_CN',
+  'zh-hans': 'zh_CN',
+  'zh-hant': 'zh_TW',
+  'zh-cn': 'zh_CN',
+  'zh-sg': 'zh_CN',
+  'zh-my': 'zh_CN',
+  'zh-tw': 'zh_TW',
+  'zh-hk': 'zh_TW',
+  'zh-mo': 'zh_TW',
+  // Other supported languages
+  'ar': 'ar',
+  'de': 'de_DE',
+  'en': 'en',
+  'es': 'es',
+  'fr': 'fr_FR',
+  'ja': 'ja_JP',
+  'ko': 'ko_KR',
+  'pt': 'pt_PT',
+  'ru': 'ru_RU',
+  'tr': 'tr_TR',
+  'uk': 'uk_UA',
+  'vi': 'vi_VN',
+}
+
+const SUPPORTED_LANGUAGES = Object.keys(i18n)
+
+interface ParsedLocale {
+  base: string
+  full: string
+}
+
+/**
+ * Parse a locale string into its base language and normalized full tag.
+ * Falls back to simple string splitting if Intl.Locale is unavailable.
+ */
+function parseLocale(locale: string): ParsedLocale {
+  const normalized = locale.toLowerCase().replace(/_/g, '-').trim()
+
+  try {
+    const intlLocale = new Intl.Locale(normalized)
+    return {
+      base: intlLocale.language.toLowerCase(),
+      full: normalized,
+    }
+  }
+  catch {
+    const parts = normalized.split('-')
+    return {
+      base: parts[0] || normalized,
+      full: normalized,
+    }
+  }
+}
+
+/**
+ * Detect the best matching supported language from the browser preferences.
+ * Returns an empty string if no supported language matches.
+ */
+export function getBrowserLanguage(): string {
+  const candidates = [
+    navigator.language,
+    ...(navigator.languages || []),
+  ].filter(Boolean) as string[]
+
+  for (const candidate of candidates) {
+    const { base, full } = parseLocale(candidate)
+
+    // Prefer full locale match (e.g. zh-CN, zh-TW)
+    if (LOCALE_MAP[full]) {
+      return LOCALE_MAP[full]
+    }
+
+    // Fall back to base language match (e.g. zh -> zh_CN)
+    if (LOCALE_MAP[base]) {
+      return LOCALE_MAP[base]
+    }
+
+    // Direct match against supported project codes
+    const directMatch = SUPPORTED_LANGUAGES.find(lang =>
+      lang.toLowerCase() === full || lang.toLowerCase().startsWith(`${base}_`),
+    )
+    if (directMatch) {
+      return directMatch
+    }
+  }
+
+  return ''
+}

--- a/app/src/lib/helper/index.ts
+++ b/app/src/lib/helper/index.ts
@@ -75,3 +75,4 @@ export {
 }
 
 export { clearFingerprintCache, getBrowserFingerprint } from './fingerprint'
+export { getBrowserLanguage } from './i18n'

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -5,6 +5,7 @@ import { createPinia } from 'pinia'
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
 import { createApp } from 'vue'
 import VueDOMPurifyHTML from 'vue-dompurify-html'
+import { getBrowserLanguage } from '@/lib/helper'
 import { setupInterceptors } from '@/lib/http/interceptors'
 import { initPWAThemeColor, watchThemeChanges } from '@/lib/pwa'
 import { useSettingsStore } from '@/pinia'
@@ -62,7 +63,16 @@ app.use(pinia)
 // after pinia created
 const settings = useSettingsStore()
 
-gettext.current = settings.language || 'en'
+// If the user has never selected a language, detect it from the browser and
+// remember the choice as if they had set it manually. They can still change it
+// later via the language selector. Fallback to English if no supported language
+// matches.
+if (!settings.language) {
+  settings.set_language(getBrowserLanguage() || 'en')
+}
+else {
+  gettext.current = settings.language
+}
 
 app.use(router).use(autoAnimatePlugin).mount('#app')
 


### PR DESCRIPTION
## Summary

This PR improves the first-time user experience by automatically detecting the browser's preferred language and remembering it as the user's language preference. It also fixes a missing dayjs locale mapping for Ukrainian (`uk_UA`).

## Changes

### 1. Auto-detect browser language on first visit

- Added `getBrowserLanguage()` helper in `app/src/lib/helper/i18n.ts`.
- Detects `navigator.language` and `navigator.languages`, normalizes BCP-47 tags, and maps them to supported project language codes.
- Handles Chinese variants correctly (`zh-CN`/`zh-Hans` -> `zh_CN`, `zh-TW`/`zh-Hant`/`zh-HK`/`zh-MO` -> `zh_TW`).
- Falls back to English when no supported language matches.
- In `app/src/main.ts`, when no explicit language preference exists, the detected browser language is saved via `settings.set_language()`, making it behave as if the user had manually selected it.

### 2. Add Ukrainian dayjs locale mapping

- Added `uk_UA: 'uk'` to `localeMap` in `app/src/components/SetLanguage/SetLanguage.vue`.
- Added the dynamic importer for `dayjs/locale/uk`.
- This ensures dates and relative times are displayed in Ukrainian when the UI language is set to Ukrainian.

## Verification

### Manual testing

- Tested in a Chinese browser environment on first visit: the UI automatically switched to `zh_CN`.
- Verified that the detected language is persisted to `localStorage` via the Pinia persisted state.
- Changing the language manually via the language selector still works and overrides the persisted value.

### Engineering checks

- `pnpm lint` passed
- `pnpm typecheck` passed