### PR TITLE
fix(kernel): apply predefined user password in skip-install mode

### DIFF
--- a/internal/kernel/skip_install.go
+++ b/internal/kernel/skip_install.go
@@ -60,22 +60,40 @@ func registerPredefinedUser(ctx context.Context) {
 		logger.Fatal(err)
 	}
 
-	u := query.User
-
-	_, err = u.First()
-
-	// Only effect when there is no user in the database
-	if !errors.Is(err, gorm.ErrRecordNotFound) || pUser.Name == "" || pUser.Password == "" {
+	// No predefined credentials configured, nothing to do
+	if pUser.Name == "" || pUser.Password == "" {
 		return
 	}
 
-	// Create a new user with the predefined name and password
+	u := query.User
+
+	user, err := u.First()
+
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		logger.Error(err)
+		return
+	}
+
 	pwd, _ := bcrypt.GenerateFromPassword([]byte(pUser.Password), bcrypt.DefaultCost)
 
-	_, err = u.Where(u.ID.Eq(1)).Updates(&model.User{
-		Name:     pUser.Name,
-		Password: string(pwd),
-	})
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		// Create the initial user when the database is empty
+		err = u.Create(&model.User{
+			Model: model.Model{
+				ID: 1,
+			},
+			Name:     pUser.Name,
+			Password: string(pwd),
+		})
+	} else if user.Password == "" {
+		// The initial user already exists but has no password, apply the
+		// predefined credentials. This happens when InitUser created the empty
+		// admin user before registerPredefinedUser runs.
+		_, err = u.Where(u.ID.Eq(1)).Updates(&model.User{
+			Name:     pUser.Name,
+			Password: string(pwd),
+		})
+	}
 
 	if err != nil {
 		logger.Error(err)

--- a/internal/kernel/skip_install_test.go
+++ b/internal/kernel/skip_install_test.go
@@ -1,0 +1,103 @@
+package kernel
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/0xJacky/Nginx-UI/model"
+	"github.com/0xJacky/Nginx-UI/query"
+	appSettings "github.com/0xJacky/Nginx-UI/settings"
+	"github.com/stretchr/testify/require"
+	cSettings "github.com/uozi-tech/cosy/settings"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupRegisterPredefinedUserTest(t *testing.T) {
+	t.Helper()
+
+	confDir := t.TempDir()
+	confPath := filepath.Join(confDir, "app.ini")
+	require.NoError(t, os.WriteFile(confPath, []byte("[app]\n[server]\nPort = 9000\n"), 0644))
+
+	appSettings.Init(confPath)
+	cSettings.ConfPath = confPath
+	appSettings.NodeSettings.SkipInstallation = true
+
+	dbPath := filepath.Join(confDir, "test.db")
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&model.User{}, &model.Passkey{}))
+	model.Use(db)
+	query.Use(db)
+	query.SetDefault(db)
+
+	t.Cleanup(func() {
+		appSettings.NodeSettings.SkipInstallation = false
+	})
+}
+
+func TestRegisterPredefinedUserCreatesUserWhenDatabaseIsEmpty(t *testing.T) {
+	setupRegisterPredefinedUserTest(t)
+
+	t.Setenv("NGINX_UI_PREDEFINED_USER_NAME", "admin")
+	t.Setenv("NGINX_UI_PREDEFINED_USER_PASSWORD", "my-secret-password")
+
+	registerPredefinedUser(context.Background())
+
+	user, err := query.User.Where(query.User.ID.Eq(1)).First()
+	require.NoError(t, err)
+	require.Equal(t, "admin", user.Name)
+	require.NotEmpty(t, user.Password)
+	require.NoError(t, bcrypt.CompareHashAndPassword([]byte(user.Password), []byte("my-secret-password")))
+}
+
+func TestRegisterPredefinedUserUpdatesEmptyPassword(t *testing.T) {
+	setupRegisterPredefinedUserTest(t)
+
+	// Simulate InitUser creating an empty-password admin user first
+	require.NoError(t, query.User.Create(&model.User{
+		Model: model.Model{
+			ID: 1,
+		},
+		Name: "admin",
+	}))
+
+	t.Setenv("NGINX_UI_PREDEFINED_USER_NAME", "admin")
+	t.Setenv("NGINX_UI_PREDEFINED_USER_PASSWORD", "my-secret-password")
+
+	registerPredefinedUser(context.Background())
+
+	user, err := query.User.Where(query.User.ID.Eq(1)).First()
+	require.NoError(t, err)
+	require.Equal(t, "admin", user.Name)
+	require.NotEmpty(t, user.Password)
+	require.NoError(t, bcrypt.CompareHashAndPassword([]byte(user.Password), []byte("my-secret-password")))
+}
+
+func TestRegisterPredefinedUserDoesNotOverwriteExistingPassword(t *testing.T) {
+	setupRegisterPredefinedUserTest(t)
+
+	existingHash, err := bcrypt.GenerateFromPassword([]byte("existing-password"), bcrypt.DefaultCost)
+	require.NoError(t, err)
+
+	require.NoError(t, query.User.Create(&model.User{
+		Model: model.Model{
+			ID: 1,
+		},
+		Name:     "admin",
+		Password: string(existingHash),
+	}))
+
+	t.Setenv("NGINX_UI_PREDEFINED_USER_NAME", "admin")
+	t.Setenv("NGINX_UI_PREDEFINED_USER_PASSWORD", "my-secret-password")
+
+	registerPredefinedUser(context.Background())
+
+	user, err := query.User.Where(query.User.ID.Eq(1)).First()
+	require.NoError(t, err)
+	require.Equal(t, string(existingHash), user.Password)
+}


### PR DESCRIPTION
## Summary

Fixes a bug where `NGINX_UI_PREDEFINED_USER_PASSWORD` was ignored when `NGINX_UI_NODE_SKIP_INSTALLATION=true`.

## Root Cause

During startup, `InitUser` creates the initial admin user (ID=1) with an empty password before `registerPredefinedUser` runs. The original logic in `registerPredefinedUser` only acted when no user existed at all, so it returned early and never applied the predefined password.

## Changes

- Updated `registerPredefinedUser` in `internal/kernel/skip_install.go` to:
  - Create the initial user when the database is empty
  - Update the existing initial user only when its password is empty
  - Leave an already-set password untouched
- Added `internal/kernel/skip_install_test.go` with tests covering all three scenarios

## Verification

- `go build ./...` passed
- `go test ./internal/kernel/... -race -cover` passed

## Breaking Change

No. This only fixes the case where skip-install mode + predefined credentials resulted in an empty password. Existing deployments with a already-set password are unaffected, and non-skip-install deployments are also unaffected.