### PR TITLE
fix(nginx_log): recover unindexed access logs for initial indexing on startup

### DIFF
--- a/internal/nginx_log/task_scheduler.go
+++ b/internal/nginx_log/task_scheduler.go
@@ -305,6 +305,13 @@ func (ts *TaskScheduler) needsRecovery(log *NginxLogWithIndex) bool {
 				return true
 			}
 		}
+
+	case string(indexer.IndexStatusNotIndexed):
+		// Newly enabled advanced indexing or a log path that has never been indexed.
+		// Schedule an initial indexing task so users do not have to wait for the
+		// incremental cron job to discover it.
+		logger.Debugf("Found unindexed log for initial indexing: %s", log.Path)
+		return true
 	}
 
 	return false

--- a/internal/nginx_log/task_scheduler_test.go
+++ b/internal/nginx_log/task_scheduler_test.go
@@ -1,0 +1,187 @@
+package nginx_log
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/0xJacky/Nginx-UI/internal/nginx_log/indexer"
+	"github.com/0xJacky/Nginx-UI/model"
+	"github.com/0xJacky/Nginx-UI/query"
+	"github.com/0xJacky/Nginx-UI/settings"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupTaskSchedulerTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&model.NginxLogIndex{}))
+
+	model.Use(db)
+	query.Use(db)
+	query.SetDefault(db)
+
+	return db
+}
+
+func TestNeedsRecovery(t *testing.T) {
+	ts := &TaskScheduler{}
+
+	tests := []struct {
+		name     string
+		status   string
+		expected bool
+	}{
+		{
+			name:     "indexing in progress should be recovered",
+			status:   string(indexer.IndexStatusIndexing),
+			expected: true,
+		},
+		{
+			name:     "queued task should be recovered",
+			status:   string(indexer.IndexStatusQueued),
+			expected: true,
+		},
+		{
+			name:     "not indexed task should be recovered for initial indexing",
+			status:   string(indexer.IndexStatusNotIndexed),
+			expected: true,
+		},
+		{
+			name:     "indexed task should not be recovered",
+			status:   string(indexer.IndexStatusIndexed),
+			expected: false,
+		},
+		{
+			name:     "error task should not be recovered when last indexed is zero",
+			status:   string(indexer.IndexStatusError),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := &NginxLogWithIndex{
+				Path:        "/var/log/nginx/access.log",
+				IndexStatus: tt.status,
+			}
+			assert.Equal(t, tt.expected, ts.needsRecovery(log))
+		})
+	}
+}
+
+func TestTaskScheduler_IsTaskInProgress(t *testing.T) {
+	ts := NewTaskScheduler(context.Background())
+	logPath := "/var/log/nginx/access.log"
+
+	assert.False(t, ts.IsTaskInProgress(logPath))
+
+	lock := ts.acquireTaskLock(logPath)
+	lock.Lock()
+	defer lock.Unlock()
+
+	assert.True(t, ts.IsTaskInProgress(logPath))
+}
+
+func TestTaskScheduler_AcquireTaskLock(t *testing.T) {
+	ts := NewTaskScheduler(context.Background())
+	logPath := "/var/log/nginx/access.log"
+
+	lock, release := ts.AcquireTaskLock(logPath)
+	assert.NotNil(t, lock)
+
+	// A second acquire for the same path should report in progress.
+	assert.True(t, ts.IsTaskInProgress(logPath))
+
+	release()
+	assert.False(t, ts.IsTaskInProgress(logPath))
+}
+
+func TestTaskScheduler_RecoverUnfinishedTasks_NilServices(t *testing.T) {
+	ts := NewTaskScheduler(context.Background())
+	ts.logFileManager = nil
+	ts.modernIndexer = nil
+
+	err := ts.RecoverUnfinishedTasks(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestTaskScheduler_RecoverUnfinishedTasks_InitialIndexing(t *testing.T) {
+	setupTaskSchedulerTestDB(t)
+
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "access.log")
+	require.NoError(t, os.WriteFile(logPath, []byte(
+		`127.0.0.1 - - [22/Jul/2026:00:00:00 +0800] "GET / HTTP/1.1" 200 42 "-" "test"`+"\n"+
+			`127.0.0.1 - - [22/Jul/2026:00:00:01 +0800] "GET /api HTTP/1.1" 200 84 "-" "test"`+"\n",
+	), 0644))
+
+	// Allow the indexer to access the test log file.
+	settings.NginxSettings.LogDirWhiteList = []string{tempDir}
+	t.Cleanup(func() {
+		settings.NginxSettings.LogDirWhiteList = nil
+	})
+
+	// Initialize services state so GetLogFileManager/GetIndexer work.
+	servicesMutex.Lock()
+	oldServicesInitialized := servicesInitialized
+	oldGlobalLogFileManager := globalLogFileManager
+	oldGlobalIndexer := globalIndexer
+	t.Cleanup(func() {
+		servicesMutex.Lock()
+		servicesInitialized = oldServicesInitialized
+		globalLogFileManager = oldGlobalLogFileManager
+		globalIndexer = oldGlobalIndexer
+		servicesMutex.Unlock()
+	})
+
+	indexDir := filepath.Join(tempDir, "index")
+	require.NoError(t, os.MkdirAll(indexDir, 0755))
+
+	indexer.InitLogParser()
+
+	indexerConfig := indexer.DefaultIndexerConfig()
+	indexerConfig.IndexPath = indexDir
+	shardManager := indexer.NewGroupedShardManager(indexerConfig)
+	idx := indexer.NewParallelIndexer(indexerConfig, shardManager)
+	require.NoError(t, idx.Start(context.Background()))
+	t.Cleanup(func() {
+		_ = idx.Stop()
+	})
+
+	lfm := indexer.NewLogFileManager()
+	lfm.SetIndexer(idx)
+	lfm.AddLogPath(logPath, "access", "access.log", "/etc/nginx/nginx.conf")
+
+	globalLogFileManager = lfm
+	globalIndexer = idx
+	servicesInitialized = true
+	servicesMutex.Unlock()
+
+	ts := NewTaskScheduler(context.Background())
+	err := ts.RecoverUnfinishedTasks(context.Background())
+	require.NoError(t, err)
+
+	// Wait for the background indexing task to complete and persist the result.
+	q := query.NginxLogIndex
+	var record *model.NginxLogIndex
+	require.Eventually(t, func() bool {
+		rec, err := q.Where(q.Path.Eq(logPath)).First()
+		if err != nil {
+			return false
+		}
+		record = rec
+		return rec.IndexStatus == string(indexer.IndexStatusIndexed) && rec.DocumentCount > 0
+	}, 30*time.Second, 200*time.Millisecond, "indexing task did not complete")
+
+	assert.Equal(t, string(indexer.IndexStatusIndexed), record.IndexStatus)
+	assert.Greater(t, record.DocumentCount, uint64(0))
+}


### PR DESCRIPTION
## Summary

When nginx log advanced indexing is enabled on a node that has no existing index records, the UI stays in a "loading" state because no initial indexing task is ever scheduled. The incremental cron job runs before the `LogFileManager` is initialized at startup, and the task scheduler only recovers tasks that are already `indexing`, `queued`, or recently `error`, ignoring never-indexed access logs.

This change makes the task scheduler also recover `not_indexed` access logs on startup, restoring the behavior that the old `background_service.go` had before the `fc968a3b` refactor.

## Root Cause

In the current architecture (`internal/nginx_log/task_scheduler.go`):

1. `RecoverUnfinishedTasks()` queries all access logs and checks `needsRecovery()`.
2. `needsRecovery()` returned `true` only for `indexing`, `queued`, or recent `error` statuses.
3. If advanced indexing is enabled for the first time, there are no `nginx_log_indices` records, so recovery finds nothing.
4. The cron-based incremental indexer runs with `WithStartImmediately()`, often before `InitializeServices()` has finished starting the `LogFileManager`, so the first run is skipped with `Log file manager not available for incremental indexing`.
5. The next cron run is 15 minutes later. During that window the frontend shows "loading" with 0 healthy shards.

The old `background_service.go` explicitly called `discoverInitialLogs()` when no indexes existed, but this logic was lost in the refactor to `modern_services.go` + `task_scheduler.go`.

## Changes

- `internal/nginx_log/task_scheduler.go`
  - Added `IndexStatusNotIndexed` to `needsRecovery()` so never-indexed access logs are scheduled for initial indexing on startup.

- `internal/nginx_log/task_scheduler_test.go` (new file)
  - `TestNeedsRecovery`: unit tests for `needsRecovery()` covering all statuses.
  - `TestTaskScheduler_IsTaskInProgress`: verifies task lock state detection.
  - `TestTaskScheduler_AcquireTaskLock`: verifies lock acquisition and release.
  - `TestTaskScheduler_RecoverUnfinishedTasks_NilServices`: edge case when services are not available.
  - `TestTaskScheduler_RecoverUnfinishedTasks_InitialIndexing`: integration test that creates an access log with no existing index, runs recovery, and asserts the log is indexed with `document_count > 0`.

## Verification

- Ran the new task scheduler tests locally and all passed.
- Ran `gofmt` and `go vet`, both clean.
- Validated the fix on a real service deployment: after clearing existing index data and restarting, the access log was automatically indexed on startup and the searcher became healthy.

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Added tests that cover the changed behavior
- [x] `gofmt` and `go vet` pass
- [x] Verified on aarch64 target hardware
