### PR TITLE
fix(model): remove gorm default:true from UpstreamConfig.Enabled

### DIFF
--- a/model/upstream_config.go
+++ b/model/upstream_config.go
@@ -3,5 +3,5 @@ package model
 type UpstreamConfig struct {
 	Model
 	Socket  string `json:"socket" gorm:"uniqueIndex"` // host:port address
-	Enabled bool   `json:"enabled" gorm:"default:true"`
+	Enabled bool   `json:"enabled"`
 }


### PR DESCRIPTION
## Summary

When disabling health check for an upstream socket for the first time, the toggle appears to stay enabled even though the UI shows a "disabled" success message. A second click is required to actually turn it off.

## Root Cause

`model/upstream_config.go` defined:

```go
Enabled bool `json:"enabled" gorm:"default:true"`
```

GORM applies `default:true` when the field value is the Go zero value. Since `false` is the zero value for `bool`, creating a new `UpstreamConfig` with `Enabled: false` caused GORM to store `true` instead.

On the first disable, the backend creates a new record, so the database ended up with `enabled = true`. The subsequent `loadData()` refreshed the switch back to the ON state. On the second click, the record already existed and the `Update` path correctly set `enabled = false`.

The default-when-no-record behavior is already handled in `GetSocketList` and `GetUpstreamList`, so the database default is unnecessary.

## Changes

- `model/upstream_config.go`: removed `gorm:"default:true"` from `UpstreamConfig.Enabled`.

## Verification

- Verified on a real service deployment: after clearing the existing `upstream_configs` row for a socket, the first click on the health check toggle now correctly disables it.