### PR TITLE
fix(self_check): wait for client close and message receipt in websocket probe

### DIFF
--- a/api/system/self_check.go
+++ b/api/system/self_check.go
@@ -39,6 +39,17 @@ func CheckWebSocket(c *gin.Context) {
 		logger.Error(err)
 		return
 	}
+
+	// Wait for the client to close after receiving the probe.
+	// Closing immediately after writing creates a race: the connection may be
+	// torn down before the browser has processed the open/message events.
+	ws.SetReadDeadline(time.Now().Add(5 * time.Second))
+	for {
+		_, _, err := ws.ReadMessage()
+		if err != nil {
+			break
+		}
+	}
 }
 
 func TimeoutCheck(c *gin.Context) {

--- a/app/src/components/SelfCheck/tasks/frontend/websocket.ts
+++ b/app/src/components/SelfCheck/tasks/frontend/websocket.ts
@@ -40,10 +40,14 @@ const WebsocketTask: FrontendTask = {
         false,
         {
           autoClose: false,
-          onConnected: () => finish(ReportStatus.Success),
+          onConnected: () => {
+            // Handshake succeeded, but wait for the actual probe message to
+            // confirm the full WebSocket path (including proxy message relay).
+          },
+          onMessage: () => finish(ReportStatus.Success),
           onError: () => finish(ReportStatus.Error),
-          // Fast loopback can deliver close before open; a clean close means
-          // the handshake succeeded.
+          // Fast loopback can deliver close before open/message; a clean close
+          // means the handshake at least succeeded.
           onDisconnected: (_ws, ev) => finish(ev.wasClean ? ReportStatus.Success : ReportStatus.Error),
         },
         selfCheck.getWebsocketQuery(options),


### PR DESCRIPTION
## Summary

The WebSocket self-check task intermittently reported failure even though the nginx reverse proxy was correctly configured. The header banner showed "Self check failed", but opening the self-check page often showed all green. In some browsers (e.g. Firefox) the `/api/self_check/websocket` connection completed with status 101 yet no probe message appeared in DevTools.

## Root Cause

The backend `CheckWebSocket` handler performed the WebSocket upgrade, wrote `{"message":"ok"}`, and immediately closed the connection:

```go
ws, err := upgrader.Upgrade(...)
defer ws.Close()
ws.WriteJSON(gin.H{"message": "ok"})
```

This created a race: for slower browsers or proxies, the TCP connection could be torn down before the browser processed the `open`/`message` events. The frontend originally finished the check on `onConnected`, so it sometimes never saw the message and fell through to `onDisconnected` with `wasClean=false`, reporting an error.

## Changes

- `api/system/self_check.go`
  - After sending the probe message, keep the connection open and read until the client closes it, with a 5-second deadline fallback.

- `app/src/components/SelfCheck/tasks/frontend/websocket.ts`
  - Move the success condition from `onConnected` to `onMessage`, confirming the probe message actually reaches the browser.
  - Keep the `onDisconnected` fallback for edge cases where the close frame arrives before the message.

## Verification

- Verified on a real service deployment that the self-check warning no longer appears on page reload.
- Confirmed via browser console that Firefox receives `onMessage: {"message":"ok"}` followed by a clean `onDisconnected`.
- Ran `pnpm lint` and `pnpm typecheck`, both clean.