### PR TITLE
fix(i18n): update VS Code PO paths

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,9 @@
 {
   "i18n-gettext.localesConfig": {
         "root": "app",
-        "type": "nested",
+        "type": "flat",
         "basePath": "src/language",
-        "pattern": "${locale}/${domain}.po",
+        "pattern": "${locale}.po",
         "defaultDomain": "app",
         "sourceLanguage": "en"
     },


### PR DESCRIPTION
## What changed

- switch the VS Code i18n Gettext workspace configuration to `flat`
- match the migrated catalogs with `${locale}.po`
- retain the `app` default domain used by the extension

## Why

PR #1710 migrated the catalogs from `src/language/<locale>/app.po` to `src/language/<locale>.po`, but `.vscode/settings.json` still pointed to the old nested layout. This prevented the i18n Gettext extension from discovering the migrated catalogs correctly.

## Validation

- `jq` configuration assertion
- `git diff --check`
- `bun run gettext:extract` (all 14 flat catalogs merged successfully; generated catalog drift discarded)
- `bun run lint`
