### PR TITLE
ci: retry OpenWrt SDK downloads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -879,13 +879,22 @@ jobs:
           SUBTARGET: ${{ matrix.subtarget }}
         run: |
           set -euo pipefail
-          base_url="https://downloads.openwrt.org/releases/${OPENWRT_VERSION}/targets/${TARGET}/${SUBTARGET}"
-          curl -fsSLo sha256sums "${base_url}/sha256sums"
+          downloads_base_url="https://downloads.openwrt.org/releases/${OPENWRT_VERSION}/targets/${TARGET}/${SUBTARGET}"
+          archive_base_url="https://archive.openwrt.org/releases/${OPENWRT_VERSION}/targets/${TARGET}/${SUBTARGET}"
+          if ! curl --retry 5 --retry-all-errors --retry-delay 2 \
+            -fsSLo sha256sums "${downloads_base_url}/sha256sums"; then
+            curl --retry 5 --retry-all-errors --retry-delay 2 \
+              -fsSLo sha256sums "${archive_base_url}/sha256sums"
+          fi
           sdk_filename="$(awk '$2 ~ /openwrt-sdk-.*Linux-x86_64.tar.zst$/ {print $2; exit}' sha256sums)"
           sdk_sha256="$(awk -v file="$sdk_filename" '$2 == file {print $1}' sha256sums)"
           test -n "$sdk_filename"
           test -n "$sdk_sha256"
-          curl -fsSLo "$sdk_filename" "${base_url}/${sdk_filename}"
+          if ! curl --retry 5 --retry-all-errors --retry-delay 2 \
+            -fsSLo "$sdk_filename" "${downloads_base_url}/${sdk_filename}"; then
+            curl --retry 5 --retry-all-errors --retry-delay 2 \
+              -fsSLo "$sdk_filename" "${archive_base_url}/${sdk_filename}"
+          fi
           echo "${sdk_sha256}  ${sdk_filename}" | sha256sum --check
           sdk_dir="$(tar --zstd -tf "$sdk_filename" | sed -n '1s#/.*##p')"
           test -n "$sdk_dir"


### PR DESCRIPTION
## Summary

- retry OpenWrt checksum and SDK downloads up to five times
- include all curl transfer and HTTP errors, including transient CDN 404 responses
- keep a fixed two-second delay between attempts
- fall back to the official `archive.openwrt.org` host when the primary download host remains unavailable

## Evidence

- all six v2.5.3 OpenWrt release jobs received HTTP 404 from the primary download host in the GitHub Runner region, including a failed-job rerun
- the same official paths return HTTP 200 through other download edges and `archive.openwrt.org`
- `actionlint` v1.7.7 passes for `.github/workflows/build.yml`
