### PR TITLE
ci: parse OpenWrt SDK checksums

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -897,8 +897,8 @@ jobs:
           }
 
           download_openwrt_file sha256sums sha256sums
-          sdk_filename="$(awk '$2 ~ /openwrt-sdk-.*Linux-x86_64.tar.zst$/ {print $2; exit}' sha256sums)"
-          sdk_sha256="$(awk -v file="$sdk_filename" '$2 == file {print $1}' sha256sums)"
+          sdk_filename="$(awk '$2 ~ /^\*?openwrt-sdk-.*\.Linux-x86_64\.tar\.zst$/ {sub(/^\*/, "", $2); print $2; exit}' sha256sums)"
+          sdk_sha256="$(awk -v file="$sdk_filename" '$2 == file || $2 == "*" file {print $1; exit}' sha256sums)"
           test -n "$sdk_filename"
           test -n "$sdk_sha256"
           download_openwrt_file "$sdk_filename" "$sdk_filename"

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -71,8 +71,14 @@ jobs:
             ipq40xx/generic
             sifiveu/generic
           )
+          checksum_file="$(mktemp)"
+          trap 'rm -f "$checksum_file"' EXIT
           for target in "${targets[@]}"; do
+            base_url="https://mirror-03.infra.openwrt.org/releases/${OPENWRT_VERSION}/targets/${target}"
             curl --retry 3 --retry-all-errors --retry-delay 2 \
-              -fsSLo /dev/null \
-              "https://mirror-03.infra.openwrt.org/releases/${OPENWRT_VERSION}/targets/${target}/sha256sums"
+              -fsSLo "$checksum_file" "${base_url}/sha256sums"
+            sdk_filename="$(awk '$2 ~ /^\*?openwrt-sdk-.*\.Linux-x86_64\.tar\.zst$/ {sub(/^\*/, "", $2); print $2; exit}' "$checksum_file")"
+            test -n "$sdk_filename"
+            curl --retry 3 --retry-all-errors --retry-delay 2 \
+              -fsSILo /dev/null "${base_url}/${sdk_filename}"
           done


### PR DESCRIPTION
## Summary
- strip the binary-mode marker from SDK filenames in OpenWrt sha256sums files
- accept both text-mode and binary-mode checksum entries when resolving the expected digest
- extend the GitHub Runner preflight to parse and HEAD the real SDK archive for every supported target

## Root cause
OpenWrt 25.12.5 publishes checksum entries as `<digest> *openwrt-sdk-...tar.zst`. The release workflow kept the leading `*` as part of the filename, so all mirror and fallback URLs correctly returned 404.

## Validation
- parsed the SDK filename for all six supported targets
- all six SDK archive HEAD requests returned success
- actionlint passed for both modified workflows
- tests/install_openwrt_test.sh passed
- git diff --check passed