### PR TITLE
feat(config): add favorites support for config management

### DIFF
--- a/app/src/composables/useConfigFavorites.ts
+++ b/app/src/composables/useConfigFavorites.ts
@@ -1,0 +1,51 @@
+import { useStorage } from '@vueuse/core'
+
+export interface ConfigFavorite {
+  name: string
+  dir: string
+  fullPath: string
+  modifiedAt: string
+}
+
+const STORAGE_KEY = 'nginx-ui-config-favorites'
+
+export function useConfigFavorites() {
+  const favorites = useStorage<ConfigFavorite[]>(STORAGE_KEY, [])
+
+  function isFavorite(fullPath: string) {
+    return favorites.value.some(item => item.fullPath === fullPath)
+  }
+
+  function addFavorite(name: string, dir: string, modifiedAt?: string) {
+    const fullPath = dir ? `${dir}/${name}` : name
+    if (isFavorite(fullPath))
+      return
+
+    favorites.value.push({
+      name,
+      dir,
+      fullPath,
+      modifiedAt: modifiedAt || '',
+    })
+  }
+
+  function removeFavorite(fullPath: string) {
+    favorites.value = favorites.value.filter(item => item.fullPath !== fullPath)
+  }
+
+  function toggleFavorite(name: string, dir: string, modifiedAt?: string) {
+    const fullPath = dir ? `${dir}/${name}` : name
+    if (isFavorite(fullPath))
+      removeFavorite(fullPath)
+    else
+      addFavorite(name, dir, modifiedAt)
+  }
+
+  return {
+    favorites,
+    isFavorite,
+    addFavorite,
+    removeFavorite,
+    toggleFavorite,
+  }
+}

--- a/app/src/layouts/SideBar.vue
+++ b/app/src/layouts/SideBar.vue
@@ -6,10 +6,15 @@ import type { NgxModule } from '@/api/ngx'
 import ngx from '@/api/ngx'
 import Logo from '@/components/Logo'
 import NodeIndicator from '@/components/NodeIndicator'
+import { useConfigFavorites } from '@/composables/useConfigFavorites'
 import { useGlobalStore } from '@/pinia/moudule/global'
 import { routes } from '@/routes'
 
 const route = useRoute()
+const { favorites } = useConfigFavorites()
+
+const CONFIG_PATH = 'config'
+const FAVORITES_KEY = `${CONFIG_PATH}-favorites`
 
 const openKeys = ref([openSub()])
 
@@ -22,6 +27,14 @@ function openSub() {
   return path.substring(1, lastSepIndex)
 }
 
+function ensureConfigOpen() {
+  const keys = new Set(openKeys.value)
+  keys.add(CONFIG_PATH)
+  if (favorites.value.length > 0)
+    keys.add(FAVORITES_KEY)
+  openKeys.value = Array.from(keys)
+}
+
 watch(route, () => {
   selectedKey.value = [route.name as Key]
 
@@ -29,7 +42,16 @@ watch(route, () => {
   const p = openKeys.value.indexOf(sub)
   if (p === -1)
     openKeys.value = [sub]
+
+  // Keep config and favorites menus expanded when in config routes
+  if (route.path.startsWith('/config'))
+    ensureConfigOpen()
 })
+
+watch(favorites, () => {
+  if (route.path.startsWith('/config'))
+    ensureConfigOpen()
+}, { immediate: true })
 
 const sidebars = computed(() => {
   return routes[0].children
@@ -51,6 +73,28 @@ interface Sidebar {
 
 const globalStore = useGlobalStore()
 const { modules, modulesMap } = storeToRefs(globalStore)
+
+function getFavoriteRoute(item: typeof favorites.value[0]) {
+  return {
+    path: `/config/${encodeURIComponent(item.name)}/edit`,
+    query: {
+      basePath: item.dir || undefined,
+    },
+  }
+}
+
+function getFavoriteTitle(item: typeof favorites.value[0]) {
+  if (item.modifiedAt) {
+    try {
+      const date = new Date(item.modifiedAt).toLocaleString()
+      return `${item.name} (${date})`
+    }
+    catch {
+      return item.name
+    }
+  }
+  return item.name
+}
 
 onMounted(() => {
   ngx.get_modules().then(r => {
@@ -116,7 +160,7 @@ const visible: ComputedRef<Sidebar[]> = computed(() => {
 
       <template v-for="s in visible">
         <AMenuItem
-          v-if="s.children.length === 0 || s.meta.hideChildren"
+          v-if="(s.children.length === 0 || s.meta.hideChildren) && !(s.path === 'config' && favorites.length > 0)"
           :key="s.name"
           @click="$router.push(`/${s.path}`).catch(() => {})"
         >
@@ -127,6 +171,7 @@ const visible: ComputedRef<Sidebar[]> = computed(() => {
         <ASubMenu
           v-else
           :key="s.path"
+          @titleClick="s.path === 'config' ? $router.push(`/${s.path}`).catch(() => {}) : null"
         >
           <template #title>
             <Component :is="s.meta.icon as IconComponentProps" />
@@ -140,6 +185,20 @@ const visible: ComputedRef<Sidebar[]> = computed(() => {
               {{ child?.meta?.name() }}
             </RouterLink>
           </AMenuItem>
+
+          <template v-if="s.path === 'config' && favorites.length > 0">
+            <AMenuDivider />
+            <ASubMenu :key="`${s.path}-favorites`" :title="$gettext('Favorites')">
+              <AMenuItem
+                v-for="item in favorites"
+                :key="`fav-${item.fullPath}`"
+              >
+                <RouterLink :to="getFavoriteRoute(item)">
+                  {{ getFavoriteTitle(item) }}
+                </RouterLink>
+              </AMenuItem>
+            </ASubMenu>
+          </template>
         </ASubMenu>
       </template>
     </AMenu>

--- a/app/src/routes/modules/config.ts
+++ b/app/src/routes/modules/config.ts
@@ -9,7 +9,7 @@ export const configRoutes: RouteRecordRaw[] = [
     meta: {
       name: () => $gettext('Manage Configs'),
       icon: FileOutlined,
-      hideChildren: true,
+      hideChildren: false,
     },
   },
   {

--- a/app/src/views/config/ConfigList.vue
+++ b/app/src/views/config/ConfigList.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
+import { StarFilled, StarOutlined } from '@ant-design/icons-vue'
 import { StdTable } from '@uozi-admin/curd'
 import config from '@/api/config'
 import FooterToolBar from '@/components/FooterToolbar'
 import InspectConfig from '@/components/InspectConfig'
 import { useBreadcrumbs } from '@/composables/useBreadcrumbs'
+import { useConfigFavorites } from '@/composables/useConfigFavorites'
 import { isProtectedPath } from '@/views/config/configUtils'
 import Delete from './components/Delete.vue'
 import Mkdir from './components/Mkdir.vue'
@@ -36,6 +38,12 @@ watch(getParams, () => {
 
 const refInspectConfig = useTemplateRef('refInspectConfig')
 const breadcrumbs = useBreadcrumbs()
+
+const { isFavorite, toggleFavorite } = useConfigFavorites()
+
+function getFullPath(name: string) {
+  return basePath.value ? `${basePath.value}${name}` : name
+}
 
 function updateBreadcrumbs() {
   const filteredPath = basePath.value
@@ -138,6 +146,7 @@ function isProtected(name: string) {
       </AButton>
     </template>
     <InspectConfig ref="refInspectConfig" />
+
     <StdTable
       :key="update"
       ref="table"
@@ -180,6 +189,20 @@ function isProtected(name: string) {
           }"
         >
           {{ $gettext('Modify') }}
+        </AButton>
+        <AButton
+          type="link"
+          size="small"
+          @click="() => toggleFavorite(record.name, basePath, record.modified_at)"
+        >
+          <template v-if="isFavorite(getFullPath(record.name))">
+            <StarFilled />
+            {{ $gettext('Unfavorite') }}
+          </template>
+          <template v-else>
+            <StarOutlined />
+            {{ $gettext('Favorite') }}
+          </template>
         </AButton>
         <AButton
           v-if="!isProtected(record.name)"


### PR DESCRIPTION
- Add useConfigFavorites composable to manage favorite config files with localStorage persistence
- Render favorites as submenu under Manage Configs in sidebar
- Add Favorite/Unfavorite button in config list actions
- Preserve config menu expansion when navigating favorite items