### PR TITLE
Show MiniMax model parameters and endpoints

### DIFF
--- a/app/src/constants/llm.ts
+++ b/app/src/constants/llm.ts
@@ -1,12 +1,61 @@
+export interface LLMModelPricing {
+  input: number
+  output: number
+  cacheRead?: number
+  cacheWrite?: number
+}
+
+export interface LLMModelPreset {
+  value: string
+  contextWindow: number
+  pricing: LLMModelPricing
+  inputModalities: string[]
+  thinkingModes: string[]
+}
+
+export interface LLMProviderEndpoint {
+  region: string
+  openaiBaseUrl: string
+  anthropicBaseUrl: string
+  docsUrl: string
+}
+
 export interface LLMProviderPreset {
   value: string
   label: string
   baseUrl?: string
+  models?: LLMModelPreset[]
+  endpoints?: LLMProviderEndpoint[]
 }
 
+const MINIMAX_MODELS: LLMModelPreset[] = [
+  {
+    value: 'MiniMax-M3',
+    contextWindow: 1_000_000,
+    pricing: {
+      input: 0.6,
+      output: 2.4,
+      cacheRead: 0.12,
+    },
+    inputModalities: ['text', 'image', 'video'],
+    thinkingModes: ['adaptive', 'disabled'],
+  },
+  {
+    value: 'MiniMax-M2.7',
+    contextWindow: 204_800,
+    pricing: {
+      input: 0.3,
+      output: 1.2,
+      cacheRead: 0.06,
+      cacheWrite: 0.375,
+    },
+    inputModalities: ['text'],
+    thinkingModes: ['always_on'],
+  },
+]
+
 export const LLM_MODELS = [
-  'MiniMax-M3',
-  'MiniMax-M2.7',
+  ...MINIMAX_MODELS.map(model => model.value),
   'deepseek-ai/deepseek-v4-flash',
   'deepseek-v3',
   'o3-mini',
@@ -35,6 +84,21 @@ export const LLM_PROVIDERS: LLMProviderPreset[] = [
     value: 'minimax',
     label: 'MiniMax',
     baseUrl: 'https://api.minimax.io/v1',
+    models: MINIMAX_MODELS,
+    endpoints: [
+      {
+        region: 'global_en',
+        openaiBaseUrl: 'https://api.minimax.io/v1',
+        anthropicBaseUrl: 'https://api.minimax.io/anthropic',
+        docsUrl: 'https://platform.minimax.io/docs',
+      },
+      {
+        region: 'cn_zh',
+        openaiBaseUrl: 'https://api.minimaxi.com/v1',
+        anthropicBaseUrl: 'https://api.minimaxi.com/anthropic',
+        docsUrl: 'https://platform.minimaxi.com/docs',
+      },
+    ],
   },
   {
     value: 'custom',
@@ -42,11 +106,10 @@ export const LLM_PROVIDERS: LLMProviderPreset[] = [
   },
 ]
 
-export const LLM_PROVIDER_BASE_URLS = [
+export const LLM_PROVIDER_BASE_URLS = [...new Set([
   'https://api.openai.com',
   'https://api.atlascloud.ai/v1',
-  'https://api.minimax.io/v1',
-  'https://api.minimaxi.com/v1',
+  ...LLM_PROVIDERS.flatMap(provider => provider.endpoints?.map(endpoint => endpoint.openaiBaseUrl) ?? []),
   'https://api.deepseek.com',
   'http://localhost:11434',
-]
+])]

--- a/app/src/views/preference/tabs/OpenAISettings.vue
+++ b/app/src/views/preference/tabs/OpenAISettings.vue
@@ -19,8 +19,52 @@ const baseUrlOptions = LLM_PROVIDER_BASE_URLS.map(baseUrl => ({
   value: baseUrl,
 }))
 
+const selectedProviderPreset = computed(() => LLM_PROVIDERS.find(
+  provider => provider.value === data.value?.openai.provider,
+))
+
+const selectedModelPreset = computed(() => selectedProviderPreset.value?.models?.find(
+  model => model.value === data.value?.openai.model,
+))
+
 function filterBaseUrlOption(inputValue: string, option?: { value?: string }) {
   return option?.value?.toLowerCase().includes(inputValue.toLowerCase()) ?? false
+}
+
+function formatRegion(region: string) {
+  if (region === 'global_en')
+    return $gettext('Global')
+
+  if (region === 'cn_zh')
+    return $gettext('China')
+
+  return region
+}
+
+function formatCapability(value: string) {
+  if (value === 'always_on')
+    return $gettext('Always on')
+
+  return value.charAt(0).toUpperCase() + value.slice(1)
+}
+
+function formatPricing() {
+  const pricing = selectedModelPreset.value?.pricing
+  if (!pricing)
+    return ''
+
+  const prices = [
+    `${$gettext('Input')}: $${pricing.input}`,
+    `${$gettext('Output')}: $${pricing.output}`,
+  ]
+
+  if (pricing.cacheRead !== undefined)
+    prices.push(`${$gettext('Cache read')}: $${pricing.cacheRead}`)
+
+  if (pricing.cacheWrite !== undefined)
+    prices.push(`${$gettext('Cache write')}: $${pricing.cacheWrite}`)
+
+  return prices.join(' · ')
 }
 
 const providerBaseUrlMap = LLM_PROVIDERS.reduce<Record<string, string>>((acc, provider) => {
@@ -103,6 +147,34 @@ watch(
         :options="modelOptions"
       />
     </AFormItem>
+    <AAlert
+      v-if="selectedModelPreset"
+      type="info"
+      show-icon
+      class="mb-6"
+    >
+      <template #message>
+        {{ $gettext('Model capabilities') }}
+      </template>
+      <template #description>
+        <div>
+          <strong>{{ $gettext('Context window') }}:</strong>
+          {{ selectedModelPreset.contextWindow.toLocaleString() }} {{ $gettext('tokens') }}
+        </div>
+        <div>
+          <strong>{{ $gettext('Input modalities') }}:</strong>
+          {{ selectedModelPreset.inputModalities.map(formatCapability).join(', ') }}
+        </div>
+        <div>
+          <strong>{{ $gettext('Thinking modes') }}:</strong>
+          {{ selectedModelPreset.thinkingModes.map(formatCapability).join(', ') }}
+        </div>
+        <div>
+          <strong>{{ $gettext('Pricing per million tokens') }}:</strong>
+          {{ formatPricing() }}
+        </div>
+      </template>
+    </AAlert>
     <AFormItem
       :label="$gettext('API Base Url')"
       :validate-status="errors?.openai?.base_url ? 'error' : ''"
@@ -116,6 +188,34 @@ watch(
         :default-active-first-option="false"
       />
     </AFormItem>
+    <AAlert
+      v-if="selectedProviderPreset?.endpoints?.length"
+      type="info"
+      show-icon
+      class="mb-6"
+    >
+      <template #message>
+        {{ $gettext('Regional endpoints') }}
+      </template>
+      <template #description>
+        <div
+          v-for="endpoint in selectedProviderPreset.endpoints"
+          :key="endpoint.region"
+          class="mb-1 last:mb-0"
+        >
+          <strong>{{ formatRegion(endpoint.region) }}:</strong>
+          OpenAI-compatible: {{ endpoint.openaiBaseUrl }} ·
+          Anthropic-compatible: {{ endpoint.anthropicBaseUrl }} ·
+          <a
+            :href="endpoint.docsUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {{ $gettext('Documentation') }}
+          </a>
+        </div>
+      </template>
+    </AAlert>
     <AFormItem
       :label="$gettext('API Proxy')"
       :validate-status="errors?.openai?.proxy ? 'error' : ''"


### PR DESCRIPTION
Reason: Surface current MiniMax model parameters and regional endpoints in the OpenAI-compatible provider settings.

Changes:
- Add model metadata for context windows, token pricing, input modalities, and thinking modes.
- Show the selected model metadata in the provider settings.
- Define and display global and China OpenAI- and Anthropic-compatible endpoints with official documentation links.
- Generate MiniMax OpenAI base URL options from the endpoint registry.

Checks:
- `bun install --frozen-lockfile`
- `bun run lint:fix`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `git diff --check`
