### PR TITLE
docs: point the Debian nginx.conf link at the current branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ http {
 }
 ```
 
-For more information: [debian/conf/nginx.conf](https://salsa.debian.org/nginx-team/nginx/-/blob/master/debian/conf/nginx.conf#L59-L60)
+For more information: [debian/conf/nginx.conf](https://salsa.debian.org/nginx-team/nginx/-/blob/debian/latest/debian/conf/nginx.conf#L60-L61)
 
 ### Installation
 

--- a/docs/zh_CN/guide/getting-started.md
+++ b/docs/zh_CN/guide/getting-started.md
@@ -23,7 +23,7 @@ http {
 }
 ```
 
-更多信息请参阅：[debian/conf/nginx.conf](https://salsa.debian.org/nginx-team/nginx/-/blob/master/debian/conf/nginx.conf#L59-L60)
+更多信息请参阅：[debian/conf/nginx.conf](https://salsa.debian.org/nginx-team/nginx/-/blob/debian/latest/debian/conf/nginx.conf#L60-L61)
 
 ## 安装
 

--- a/docs/zh_TW/guide/getting-started.md
+++ b/docs/zh_TW/guide/getting-started.md
@@ -23,7 +23,7 @@ http {
 }
 ```
 
-更多資訊請參閱：[debian/conf/nginx.conf](https://salsa.debian.org/nginx-team/nginx/-/blob/master/debian/conf/nginx.conf#L59-L60)
+更多資訊請參閱：[debian/conf/nginx.conf](https://salsa.debian.org/nginx-team/nginx/-/blob/debian/latest/debian/conf/nginx.conf#L60-L61)
 
 ## 安裝
 

--- a/resources/readme/README-es.md
+++ b/resources/readme/README-es.md
@@ -113,7 +113,7 @@ http {
 }
 ```
 
-Para más información: [debian/conf/nginx.conf](https://salsa.debian.org/nginx-team/nginx/-/blob/master/debian/conf/nginx.conf#L59-L60)
+Para más información: [debian/conf/nginx.conf](https://salsa.debian.org/nginx-team/nginx/-/blob/debian/latest/debian/conf/nginx.conf#L60-L61)
 
 ### Instalación
 

--- a/resources/readme/README-ja_JP.md
+++ b/resources/readme/README-ja_JP.md
@@ -137,7 +137,7 @@ http {
 }
 ```
 
-詳細: [debian/conf/nginx.conf](https://salsa.debian.org/nginx-team/nginx/-/blob/master/debian/conf/nginx.conf#L59-L60)
+詳細: [debian/conf/nginx.conf](https://salsa.debian.org/nginx-team/nginx/-/blob/debian/latest/debian/conf/nginx.conf#L60-L61)
 
 ### インストール
 

--- a/resources/readme/README-vi_VN.md
+++ b/resources/readme/README-vi_VN.md
@@ -127,7 +127,7 @@ http {
 }
 ```
 
-Để biết thêm thông tin: [debian/conf/nginx.conf](https://salsa.debian.org/nginx-team/nginx/-/blob/master/debian/conf/nginx.conf#L59-L60)
+Để biết thêm thông tin: [debian/conf/nginx.conf](https://salsa.debian.org/nginx-team/nginx/-/blob/debian/latest/debian/conf/nginx.conf#L60-L61)
 
 ### Cài đặt
 

--- a/resources/readme/README-zh_CN.md
+++ b/resources/readme/README-zh_CN.md
@@ -112,7 +112,7 @@ http {
 }
 ```
 
-更多信息请参阅：[debian/conf/nginx.conf](https://salsa.debian.org/nginx-team/nginx/-/blob/master/debian/conf/nginx.conf#L59-L60)
+更多信息请参阅：[debian/conf/nginx.conf](https://salsa.debian.org/nginx-team/nginx/-/blob/debian/latest/debian/conf/nginx.conf#L60-L61)
 
 ### 安装
 

--- a/resources/readme/README-zh_TW.md
+++ b/resources/readme/README-zh_TW.md
@@ -114,7 +114,7 @@ http {
 }
 ```
 
-更多資訊請參閱：[debian/conf/nginx.conf](https://salsa.debian.org/nginx-team/nginx/-/blob/master/debian/conf/nginx.conf#L59-L60)
+更多資訊請參閱：[debian/conf/nginx.conf](https://salsa.debian.org/nginx-team/nginx/-/blob/debian/latest/debian/conf/nginx.conf#L60-L61)
 
 ### 安裝
 


### PR DESCRIPTION
The link to Debian's packaged `nginx.conf` returns 404. salsa.debian.org renamed the packaging branch from `master` to `debian/latest`:

```
blob/master/debian/conf/nginx.conf         -> 404
blob/debian/latest/debian/conf/nginx.conf  -> 200
```

`docs/guide/getting-started.md` was already updated, but the README, the two translated guides, and five translated READMEs still point at the old branch.

This uses the same anchor the English guide uses (`#L60-L61`) rather than carrying over the old `#L59-L60`. The line numbers shifted between branches, and on `debian/latest` lines 60-61 are the two `include` directives the surrounding text refers to:

```
60      include /etc/nginx/conf.d/*.conf;
61      include /etc/nginx/sites-enabled/*;
```

Files touched: `README.md`, `docs/zh_CN/`, `docs/zh_TW/`, and `resources/readme/README-{es,ja_JP,vi_VN,zh_CN,zh_TW}.md`. One line each, no other changes.
