### PR TITLE
fix(cluster): show the error text when a remote node is unreachable

### DIFF
--- a/api/cluster/nginx.go
+++ b/api/cluster/nginx.go
@@ -49,7 +49,7 @@ func syncReload(nodeIDs []uint64) {
 			resp, err := client.R().
 				Post("/api/nginx/reload")
 			if err != nil {
-				notification.Error("Reload Remote Nginx Error", "", err.Error())
+				notification.Error("Reload Remote Nginx Error", err.Error(), nil)
 				return
 			}
 			if resp.StatusCode() != http.StatusOK {
@@ -102,7 +102,7 @@ func syncRestart(nodeIDs []uint64) {
 			resp, err := client.R().
 				Post("/api/nginx/restart")
 			if err != nil {
-				notification.Error("Restart Remote Nginx Error", "", err.Error())
+				notification.Error("Restart Remote Nginx Error", err.Error(), nil)
 				return
 			}
 			if resp.StatusCode() != http.StatusOK {

--- a/internal/site/disable.go
+++ b/internal/site/disable.go
@@ -84,7 +84,7 @@ func syncDisable(name string) {
 			resp, err := client.R().
 				Post(fmt.Sprintf("/api/sites/%s/disable", name))
 			if err != nil {
-				notification.Error("Disable Remote Site Error", "", err.Error())
+				notification.Error("Disable Remote Site Error", err.Error(), nil)
 				return
 			}
 			if resp.StatusCode() != http.StatusOK {


### PR DESCRIPTION
Three `notification.Error` calls pass the error into the `details` slot and leave `content` empty:

```go
notification.Error("Reload Remote Nginx Error", "", err.Error())
```

The signature is `Error(title, content string, details any)`, so the notification renders with a blank body. `Notification.vue:166` does `$gettext(item.content, item.details)` and vue3-gettext returns `""` for an empty msgid; `external.go:130` returns `Content` directly when `Details` is not a translatable map, and a bare string is not. The reason is discarded at every layer, so the operator sees a red "Reload Remote Nginx Error" toast with nothing in it.

These are the `client.R().Post(...)` transport failures — the node-unreachable path, which is when the message matters most. The adjacent non-2xx branch in the same function already reports properly.

The other 17 `notification.Error` call sites already use `err.Error()` as content, so this just brings these three in line.

## No new translatable strings

`cmd/notification/generate.go` AST-scans for notification calls and regenerates `notifications.ts`, which feeds the `.po` catalogs. It skips any call whose content argument is a variable or function call (`generate.go:134`), and `err.Error()` is one — so I ran the generator and confirmed `notifications.ts` is byte-identical (same md5 before and after). No `.po` churn.

`go build -tags=unembed` passes on both packages.
