### PR TITLE
fix(cluster): building the WebSocket URL rewrites every http in it

### DIFF
--- a/model/node.go
+++ b/model/node.go
@@ -1,8 +1,8 @@
 package model
 
 import (
+	"net"
 	"net/url"
-	"strings"
 	"time"
 )
 
@@ -94,18 +94,21 @@ func (n *Node) GetWebSocketURL(uri string) (decodedUri string, err error) {
 		return
 	}
 
+	// Switch the scheme on the parsed URL instead of rewriting the rendered
+	// string, so a host, path, or query value that happens to contain "http"
+	// is left untouched.
 	defaultPort := ""
-	if baseUrl.Port() == "" {
-		switch baseUrl.Scheme {
-		default:
-			fallthrough
-		case "http":
-			defaultPort = "80"
-		case "https":
-			defaultPort = "443"
-		}
+	switch baseUrl.Scheme {
+	case "https", "wss":
+		defaultPort = "443"
+		baseUrl.Scheme = "wss"
+	default:
+		defaultPort = "80"
+		baseUrl.Scheme = "ws"
+	}
 
-		baseUrl.Host = baseUrl.Hostname() + ":" + defaultPort
+	if baseUrl.Port() == "" {
+		baseUrl.Host = net.JoinHostPort(baseUrl.Hostname(), defaultPort)
 	}
 
 	u, err := url.JoinPath(baseUrl.String(), uri)
@@ -119,7 +122,6 @@ func (n *Node) GetWebSocketURL(uri string) (decodedUri string, err error) {
 	if err != nil {
 		return
 	}
-	// http will be replaced with ws, https will be replaced with wss
-	decodedUri = strings.ReplaceAll(decodedUri, "http", "ws")
+
 	return
 }

--- a/model/node_test.go
+++ b/model/node_test.go
@@ -1,0 +1,62 @@
+package model
+
+import "testing"
+
+func TestNodeGetWebSocketURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		uri  string
+		want string
+	}{
+		{
+			name: "https gets the wss scheme and the default port",
+			url:  "https://node.example.com",
+			uri:  "/api/analytic/intro",
+			want: "wss://node.example.com:443/api/analytic/intro",
+		},
+		{
+			name: "http gets the ws scheme and the default port",
+			url:  "http://node.example.com",
+			uri:  "/api/analytic/intro",
+			want: "ws://node.example.com:80/api/analytic/intro",
+		},
+		{
+			name: "an explicit port is kept",
+			url:  "https://node.example.com:9000",
+			uri:  "/api/analytic/intro",
+			want: "wss://node.example.com:9000/api/analytic/intro",
+		},
+		{
+			name: "a host containing http is left intact",
+			url:  "https://http-proxy.example.com:9000",
+			uri:  "/api/analytic/intro",
+			want: "wss://http-proxy.example.com:9000/api/analytic/intro",
+		},
+		{
+			name: "a base path containing http is left intact",
+			url:  "http://10.0.0.1:9000/httpd",
+			uri:  "/api/analytic/intro",
+			want: "ws://10.0.0.1:9000/httpd/api/analytic/intro",
+		},
+		{
+			name: "a query value containing http is left intact",
+			url:  "https://node.example.com:9000",
+			uri:  "/api/nginx_log?type=http",
+			want: "wss://node.example.com:9000/api/nginx_log?type=http",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			node := &Node{URL: test.url}
+			got, err := node.GetWebSocketURL(test.uri)
+			if err != nil {
+				t.Fatalf("GetWebSocketURL returned error: %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("expected %q, got %q", test.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`Node.GetWebSocketURL` swaps the scheme by rewriting the finished URL string:

```go
// http will be replaced with ws, https will be replaced with wss
decodedUri = strings.ReplaceAll(decodedUri, "http", "ws")
```

`ReplaceAll` hits every occurrence, not just the scheme. Any node whose hostname,
base path, or request query contains `http` gets a corrupted target:

```
before:
node=https://http-proxy.example.com:9000  ws=wss://ws-proxy.example.com:9000/api/analytic/intro
node=http://10.0.0.1:9000/httpd           ws=ws://10.0.0.1:9000/wsd/api/analytic/intro
query  /api/nginx_log?type=http           ws=wss://node.example.com:443/api/nginx_log?type=ws

after:
node=https://http-proxy.example.com:9000  ws=wss://http-proxy.example.com:9000/api/analytic/intro
node=http://10.0.0.1:9000/httpd           ws=ws://10.0.0.1:9000/httpd/api/analytic/intro
query  /api/nginx_log?type=http           ws=wss://node.example.com:443/api/nginx_log?type=http
```

The first case sends the proxied WebSocket to a different host entirely. Both
callers are affected, `internal/middleware/proxy_ws.go` (which passes
`c.Request.RequestURI`, so the query is attacker-adjacent user input) and
`internal/analytic/node_record.go`.

## The fix

Set `baseUrl.Scheme` on the parsed URL before rendering, instead of rewriting the
rendered string. The scheme is then the only thing that changes, by construction.

The default-port logic moves into the same switch since it keys off the same
value. `wss` is accepted alongside `https` so a node URL already written with a
WebSocket scheme is not silently downgraded to port 80.

One incidental change: the host is rebuilt with `net.JoinHostPort` rather than
string concatenation, so an IPv6 literal is bracketed correctly. Concatenating
would produce `::1:80`, which does not parse.

## Verification

`TestNodeGetWebSocketURL`, six cases: the two ordinary schemes, an explicit port,
and the three `http`-in-the-URL cases above.

Restoring the `ReplaceAll` line fails exactly the three:

```
--- FAIL: TestNodeGetWebSocketURL/a_host_containing_http_is_left_intact
    node_test.go:58: expected "wss://http-proxy.example.com:9000/api/analytic/intro", got "wss://ws-proxy.example.com:9000/api/analytic/intro"
--- FAIL: TestNodeGetWebSocketURL/a_base_path_containing_http_is_left_intact
    node_test.go:58: expected "ws://10.0.0.1:9000/httpd/api/analytic/intro", got "ws://10.0.0.1:9000/wsd/api/analytic/intro"
--- FAIL: TestNodeGetWebSocketURL/a_query_value_containing_http_is_left_intact
    node_test.go:58: expected "wss://node.example.com:9000/api/nginx_log?type=http", got "wss://node.example.com:9000/api/nginx_log?type=ws"
```

The three scheme and port cases pass under that mutation, which is what pins the
existing behaviour.

`GOWORK=off go test -tags=unembed -count=1 ./...` exits 0 across 71 packages.
`go vet ./model/` is clean.

Two notes:

- I ran the suite with `umask 022`, as CI does. Under this sandbox's default
  `0077`, `internal/config`, `internal/site` and `internal/stream` fail their
  permission-restore assertions, before and after this change alike.
- `gofumpt -l` lists `model/node.go`, but it does so on an unmodified checkout
  too, along with `acme_user.go`, `cert.go` and `llm_session.go`. I left the
  pre-existing formatting alone rather than mixing a reformat into this change.

*Disclosure: written with AI assistance (Claude Code). I produced the before and after table by running the real function against each node URL, and ran the mutation check and the full suite myself.*
