### PR TITLE
fix(llm): truncating a session title splits a multi-byte character

### DIFF
--- a/internal/llm/title_generator.go
+++ b/internal/llm/title_generator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/0xJacky/Nginx-UI/settings"
 	"github.com/sashabaranov/go-openai"
@@ -101,9 +102,7 @@ func extractContextForTitleGeneration(messages []openai.ChatCompletionMessage) s
 		}
 
 		// Truncate very long messages
-		if len(content) > 200 {
-			content = content[:200] + "..."
-		}
+		content = truncateRunes(content, 200)
 
 		newContent := fmt.Sprintf("%s%s\n", rolePrefix, content)
 
@@ -119,6 +118,27 @@ func extractContextForTitleGeneration(messages []openai.ChatCompletionMessage) s
 	return contextBuilder.String()
 }
 
+// truncateRunes shortens a string to at most maxRunes runes and appends an
+// ellipsis when anything was cut. Counting runes rather than bytes matters
+// because a byte-indexed cut lands in the middle of a multi-byte character for
+// any non-ASCII text (Chinese, Japanese, Cyrillic, emoji, accented Latin) and
+// leaves an invalid UTF-8 sequence behind, which the UI renders as U+FFFD.
+func truncateRunes(value string, maxRunes int) string {
+	if maxRunes <= 0 || utf8.RuneCountInString(value) <= maxRunes {
+		return value
+	}
+
+	count := 0
+	for offset := range value {
+		if count == maxRunes {
+			return value[:offset] + "..."
+		}
+		count++
+	}
+
+	return value
+}
+
 // sanitizeTitle cleans up the generated title
 func sanitizeTitle(title string) string {
 	// Remove quotes if present
@@ -130,8 +150,8 @@ func sanitizeTitle(title string) string {
 	}
 
 	// Limit length
-	if len(title) > 50 {
-		title = title[:47] + "..."
+	if utf8.RuneCountInString(title) > 50 {
+		title = truncateRunes(title, 47)
 	}
 
 	// Replace any problematic characters

--- a/internal/llm/title_generator_test.go
+++ b/internal/llm/title_generator_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/0xJacky/Nginx-UI/settings"
 	"github.com/sashabaranov/go-openai"
@@ -59,5 +60,53 @@ func TestGenerateSessionTitleUsesMaxCompletionTokens(t *testing.T) {
 	}
 	if _, exists := requestBody["temperature"]; exists {
 		t.Fatal("request contains a temperature unsupported by reasoning models")
+	}
+}
+
+func TestSanitizeTitleKeepsMultiByteCharactersIntact(t *testing.T) {
+	// 62 runes / 186 bytes: a byte-indexed cut at 47 lands inside a character.
+	long := "配置 Nginx 反向代理与负载均衡的最佳实践指南大全示例文档，包含上游健康检查、缓存策略与证书自动续期的完整说明"
+
+	got := sanitizeTitle(long)
+
+	if !utf8.ValidString(got) {
+		t.Fatalf("sanitizeTitle(%q) = %q, which is not valid UTF-8", long, got)
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Fatalf("sanitizeTitle(%q) = %q, want a truncated value ending in an ellipsis", long, got)
+	}
+	if !strings.HasPrefix(long, strings.TrimSuffix(got, "...")) {
+		t.Fatalf("sanitizeTitle(%q) = %q, which is not a prefix of the input", long, got)
+	}
+}
+
+func TestSanitizeTitleKeepsAsciiThreshold(t *testing.T) {
+	// an ASCII title is one byte per rune, so the 50-character threshold and the
+	// 47-character cut must land exactly where they did before.
+	for _, size := range []int{47, 48, 50, 51} {
+		title := strings.Repeat("a", size)
+		got := sanitizeTitle(title)
+
+		if size <= 50 {
+			if got != title {
+				t.Fatalf("sanitizeTitle(%d chars) = %q, want it untouched", size, got)
+			}
+			continue
+		}
+		if got != strings.Repeat("a", 47)+"..." {
+			t.Fatalf("sanitizeTitle(%d chars) = %q, want 47 characters plus an ellipsis", size, got)
+		}
+	}
+}
+
+func TestExtractContextForTitleGenerationKeepsMultiByteCharactersIntact(t *testing.T) {
+	long := strings.Repeat("配", 300)
+
+	got := extractContextForTitleGeneration([]openai.ChatCompletionMessage{
+		{Role: openai.ChatMessageRoleUser, Content: long},
+	})
+
+	if !utf8.ValidString(got) {
+		t.Fatalf("extractContextForTitleGeneration() = %q, which is not valid UTF-8", got)
 	}
 }


### PR DESCRIPTION
LLM session titles are truncated with a byte index, so any non-ASCII title is cut
in the middle of a character and stored as invalid UTF-8.

`GenerateSessionTitle` against a stubbed transport, same input both runs:

```
before:
session title : 配置 Nginx 反向代理与负载均衡的最<invalid byte>...
valid UTF-8   : false

after:
session title : 配置 Nginx 反向代理与负载均衡的最佳实践指南大全示例文档，包含上游健康检查、缓存策略与证...
valid UTF-8   : true
```

The UI renders the broken tail as U+FFFD. Chinese is one of this project's own UI
languages, so this is reachable in ordinary use, and it also affects Japanese,
Cyrillic, emoji and accented Latin.

## Cause

Two byte slices on strings that are not guaranteed to be ASCII:

```go
if len(content) > 200 {
    content = content[:200] + "..."
}
...
if len(title) > 50 {
    title = title[:47] + "..."
}
```

`len` counts bytes, and a Chinese character is three of them, so index 47 lands
inside one.

## The fix

A `truncateRunes` helper that walks to a rune boundary, following the same
pattern already used in `internal/dns/providers/azuredns/records.go`.

**The thresholds are deliberately unchanged for ASCII.** My first version applied
`truncateRunes(title, 47)` unconditionally, which quietly moved the cut-off: a
48-character ASCII title used to pass through untouched and would have started
being truncated. I caught it by diffing old against new across every ASCII length
from 1 to 60, and kept the `> 50` guard so the existing behaviour is preserved
exactly. Only the multi-byte case changes.

## Verification

Three tests:

- `TestSanitizeTitleKeepsMultiByteCharactersIntact`, on a 62-rune Chinese title
- `TestExtractContextForTitleGenerationKeepsMultiByteCharactersIntact`, on the 200-byte context path
- `TestSanitizeTitleKeepsAsciiThreshold`, which pins the ASCII boundary at 47, 48, 50 and 51 characters

Replacing the rune walk with `value[:maxRunes] + "..."` fails the first two:

```
sanitizeTitle(...) = "配置 Nginx 反向代理与负载均衡的最\xe4...", which is not valid UTF-8
extractContextForTitleGeneration() = "User: 配配配配 [...66 repeats...] 配\xe9\x85...\n", which is not valid UTF-8
```

Dropping the `> 50` guard fails the third, which is the regression described
above:

```
sanitizeTitle(48 chars) = "aaa...aaa...", want it untouched
```

`umask 022; GOWORK=off go test -tags=unembed -count=1 ./...` exits 0 with no
failures. `gofmt` clean on both files.

Two notes:

- `golangci-lint` cannot typecheck this repo here, because `app/app.go` embeds
  `all:dist` and there is no frontend build available (no pnpm or bun). That is
  pre-existing and affects every package, not this change.
- `code_completion.go` and `prompts.go` in the same package are unformatted at
  HEAD; I left them alone rather than mix a reformat into this diff.

*Disclosure: written with AI assistance (Claude Code). I produced the before and after by driving GenerateSessionTitle end to end against a stubbed transport, ran all three mutation checks myself, and found the threshold regression by diffing the old and new behaviour across every ASCII length.*
