### PR TITLE
fix(nginx): an upstream comment is repeated on every following directive

### DIFF
--- a/internal/nginx/build_config.go
+++ b/internal/nginx/build_config.go
@@ -54,14 +54,17 @@ func (c *NgxConfig) BuildConfig() (content string, err error) {
 	for _, u := range c.Upstreams {
 
 		upstream := ""
-		var comments string
 		for _, directive := range u.Directives {
+			// Scope the comment to a single directive. Hoisting it out of the
+			// loop would re-emit the previous directive's comment on every
+			// following directive that has none.
+			var comments string
 			if directive.Comments != "" {
 				comments = buildComments(directive.Comments, 1)
 			}
 			upstream += fmt.Sprintf("%s\t%s;\n", comments, directive.Orig())
 		}
-		comments = buildComments(u.Comments, 1)
+		comments := buildComments(u.Comments, 1)
 		content += fmt.Sprintf("upstream %s {\n%s%s}\n\n", u.Name, comments, upstream)
 	}
 

--- a/internal/nginx/build_config_test.go
+++ b/internal/nginx/build_config_test.go
@@ -1,0 +1,78 @@
+package nginx
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildConfig_UpstreamCommentIsNotRepeated guards against a comment on one
+// upstream directive leaking onto every following directive that has none.
+func TestBuildConfig_UpstreamCommentIsNotRepeated(t *testing.T) {
+	content := `upstream backend {
+    # primary node
+    server 10.0.0.1:8080;
+    server 10.0.0.2:8080;
+    server 10.0.0.3:8080;
+}
+`
+
+	ngxConfig, err := ParseNgxConfigByContent(content)
+	if err != nil {
+		t.Fatalf("ParseNgxConfigByContent() error = %v", err)
+	}
+
+	built, err := ngxConfig.BuildConfig()
+	if err != nil {
+		t.Fatalf("BuildConfig() error = %v", err)
+	}
+
+	if got := strings.Count(built, "# primary node"); got != 1 {
+		t.Fatalf("BuildConfig() emitted the comment %d times, want 1:\n%s", got, built)
+	}
+
+	for _, server := range []string{"server 10.0.0.1:8080;", "server 10.0.0.2:8080;", "server 10.0.0.3:8080;"} {
+		if !strings.Contains(built, server) {
+			t.Fatalf("BuildConfig() = %q, want it to contain %q", built, server)
+		}
+	}
+}
+
+// TestBuildConfig_UpstreamPerDirectiveComments keeps each directive paired with
+// its own comment rather than with whichever comment came last.
+func TestBuildConfig_UpstreamPerDirectiveComments(t *testing.T) {
+	content := `upstream backend {
+    # first
+    server 10.0.0.1:8080;
+    # second
+    server 10.0.0.2:8080;
+    server 10.0.0.3:8080;
+}
+`
+
+	ngxConfig, err := ParseNgxConfigByContent(content)
+	if err != nil {
+		t.Fatalf("ParseNgxConfigByContent() error = %v", err)
+	}
+
+	built, err := ngxConfig.BuildConfig()
+	if err != nil {
+		t.Fatalf("BuildConfig() error = %v", err)
+	}
+
+	firstIdx := strings.Index(built, "# first")
+	secondIdx := strings.Index(built, "# second")
+	thirdIdx := strings.Index(built, "server 10.0.0.3:8080;")
+	if firstIdx == -1 || secondIdx == -1 || thirdIdx == -1 {
+		t.Fatalf("BuildConfig() = %q, want it to contain both comments and the last server", built)
+	}
+	if got := strings.Count(built, "# first"); got != 1 {
+		t.Fatalf("BuildConfig() emitted %q %d times, want 1:\n%s", "# first", got, built)
+	}
+	if got := strings.Count(built, "# second"); got != 1 {
+		t.Fatalf("BuildConfig() emitted %q %d times, want 1:\n%s", "# second", got, built)
+	}
+	// The uncommented third server must not inherit the second comment.
+	if secondIdx > thirdIdx {
+		t.Fatalf("BuildConfig() placed %q after the uncommented server:\n%s", "# second", built)
+	}
+}


### PR DESCRIPTION
A comment on one directive inside an `upstream` block is re-emitted above every
following directive that has no comment of its own, so it multiplies on each
save.

Parse and rebuild a 3-server upstream carrying one comment:

```
before:
upstream backend {
    # primary node
    server 10.0.0.1:8080;
    # primary node
    server 10.0.0.2:8080;
    # primary node
    server 10.0.0.3:8080;
}

after:
upstream backend {
    # primary node
    server 10.0.0.1:8080;
    server 10.0.0.2:8080;
    server 10.0.0.3:8080;
}
```

Since saving a site through the UI or API goes through parse and rebuild, the
duplication accumulates every time.

## Cause

`comments` is declared outside the directive loop, so it keeps the previous
directive's value:

```go
upstream := ""
var comments string
for _, directive := range u.Directives {
    if directive.Comments != "" {
        comments = buildComments(directive.Comments, 1)
    }
    upstream += fmt.Sprintf("%s\t%s;\n", comments, directive.Orig())
}
```

The `server {}` block a few lines below already declares its `comments` inside
the loop, in two places, so this is an inconsistency rather than an intended
difference.

## The fix

Move the declaration inside the loop, matching the `server {}` path. The
block-level `u.Comments` output is unchanged.

## Verification

Two tests: one asserting a single comment stays single across three directives,
and one asserting that two directives with their own comments each keep theirs,
once, on the right directive. The second is there so the fix cannot go too far in
the other direction and drop legitimate comments.

Hoisting `comments` back out of the loop fails both:

```
--- FAIL: TestBuildConfig_UpstreamCommentIsNotRepeated
    build_config_test.go:30: BuildConfig() emitted the comment 3 times, want 1
--- FAIL: TestBuildConfig_UpstreamPerDirectiveComments
    build_config_test.go:72: BuildConfig() emitted "# second" 2 times, want 1
```

`umask 022; GOWORK=off go test -tags=unembed -count=1 ./...` exits 0 with no
failures. `gofmt` clean on both files.

One thing I left alone: the comment text itself round-trips through
`buildComment()`, which strips `#` characters from the source. That is a separate
concern and this PR does not touch it.

*Disclosure: written with AI assistance (Claude Code). I produced the before and after by parsing and rebuilding the config shown, and ran the mutation check myself.*
