### PR TITLE
fix(nginx): log level constants are off by one, so [error] is treated as success

### DIFF
--- a/internal/nginx/log_level.go
+++ b/internal/nginx/log_level.go
@@ -5,9 +5,12 @@ import "strings"
 // refer to https://nginx.org/en/docs/ngx_core_module.html#error_log
 // nginx log level: debug, info, notice, warn, error, crit, alert, or emerg
 
+const Unknown = -1
+
+// The values below must stay aligned with the indexes of logLevel, because
+// GetLogLevel returns an index into that slice.
 const (
-	Unknown = -1
-	Debug   = iota
+	Debug = iota
 	Info
 	Notice
 	Warn

--- a/internal/nginx/log_level_test.go
+++ b/internal/nginx/log_level_test.go
@@ -1,0 +1,28 @@
+package nginx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLogLevelMatchesLevelConstants(t *testing.T) {
+	assert.Equal(t, Debug, GetLogLevel("nginx: [debug] test"))
+	assert.Equal(t, Info, GetLogLevel("nginx: [info] test"))
+	assert.Equal(t, Notice, GetLogLevel("nginx: [notice] configuration file test is successful"))
+	assert.Equal(t, Warn, GetLogLevel("nginx: [warn] conflicting server name"))
+	assert.Equal(t, Error, GetLogLevel("nginx: [error] invalid PID number"))
+	assert.Equal(t, Crit, GetLogLevel("nginx: [crit] test"))
+	assert.Equal(t, Alert, GetLogLevel("nginx: [alert] test"))
+	assert.Equal(t, Emerg, GetLogLevel("nginx: [emerg] bind() to 0.0.0.0:80 failed"))
+	assert.Equal(t, Unknown, GetLogLevel("nginx: something else"))
+}
+
+func TestControlResultIsErrorForErrorLevelOutput(t *testing.T) {
+	result := Control(func() (string, error) {
+		return "nginx: [error] invalid PID number in /run/nginx.pid", nil
+	})
+
+	assert.True(t, result.IsError())
+	assert.Equal(t, Error, result.GetLevel())
+}


### PR DESCRIPTION
`Unknown = -1` and `Debug = iota` sit in the same const block, so iota is already 1 when it reaches `Debug`. Every level constant ends up one higher than the `logLevel` index that `GetLogLevel` actually returns.

The visible effect is in `IsError`, which tests `GetLogLevel(stdOut) > Warn`. With `Warn` reading as 4 instead of 3, nginx output at `[error]` is treated as success:

```
before   Debug=1 Info=2 Notice=3 Warn=4 Error=5 Crit=6 Alert=7 Emerg=8
         "[error] invalid PID number"   GetLogLevel=4   IsError=false

after    Debug=0 Info=1 Notice=2 Warn=3 Error=4 Crit=5 Alert=6 Emerg=7
         "[error] invalid PID number"   GetLogLevel=4   IsError=true
```

`[crit]` and `[alert]` were already caught, since they sit far enough above the shifted threshold, so `[error]` is the level that changes. `[warn]` stays non-error either way. The frontend enum in `app/src/constants/config.ts` is 0..7 and already matched the slice.

Moving `Unknown` into its own const block is enough. Test added asserting the constants equal the indexes `GetLogLevel` returns, plus one on `IsError` for `[error]` output; reverting the const block fails both. `GOWORK=off go test -tags=unembed -race -cover -count=1 ./internal/nginx/...` passes, gofmt and vet clean.

AI disclosure: written with Claude Code. I probed the constants before and after and checked the mutation myself.