### PR TITLE
fix(backup): panic when the S3 storage path is the bucket root

### DIFF
--- a/internal/backup/s3_client.go
+++ b/internal/backup/s3_client.go
@@ -191,22 +191,15 @@ func getS3Region(region string) string {
 // Returns:
 //   - string: Properly formatted S3 object key
 func constructS3Key(storagePath, filename string) string {
-	// Ensure storage path doesn't start with slash and ends with slash
+	// Ensure storage path doesn't start with slash and ends with slash.
+	// A path made only of slashes ("/", "//") means the bucket root, and
+	// trimming it leaves an empty prefix rather than an out-of-range index.
+	storagePath = strings.Trim(storagePath, "/")
 	if storagePath == "" {
 		return filename
 	}
 
-	// Remove leading slash if present
-	if storagePath[0] == '/' {
-		storagePath = storagePath[1:]
-	}
-
-	// Add trailing slash if not present
-	if storagePath[len(storagePath)-1] != '/' {
-		storagePath += "/"
-	}
-
-	return storagePath + filename
+	return storagePath + "/" + filename
 }
 
 // readFileContent reads the entire content of a file into memory.

--- a/internal/backup/s3_client_test.go
+++ b/internal/backup/s3_client_test.go
@@ -50,6 +50,22 @@ func TestConstructS3Key(t *testing.T) {
 			filename:    "backup.zip",
 			expected:    "nginx-ui/backups/backup.zip",
 		},
+		{
+			// "/" is what an operator types to upload to the bucket root.
+			// Stripping the leading slash leaves an empty string, and the
+			// trailing-slash check then indexed storagePath[-1] and panicked,
+			// taking down the process from the auto backup cron goroutine.
+			name:        "storage path is bucket root",
+			storagePath: "/",
+			filename:    "backup.zip",
+			expected:    "backup.zip",
+		},
+		{
+			name:        "storage path is repeated slashes",
+			storagePath: "//",
+			filename:    "backup.zip",
+			expected:    "backup.zip",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
`constructS3Key` panics when the S3 auto backup Storage Path is `/`:

```
panic: runtime error: index out of range [-1]
```

It strips the leading slash first, which leaves `""`, then reads `storagePath[len(storagePath)-1]`. The empty-string guard runs before the strip, so it never catches this case. `//` fails the same way.

This matters more than a bad config value normally would because the call sits in the auto backup path, `internal/cron/auto_backup.go` -> `ExecuteAutoBackup` -> `handleS3Storage` -> `UploadBackupFiles`, which runs in a cron goroutine with no `recover()`. An unrecovered panic there takes the whole process down. The Storage Path field is free text with placeholder `S3 path (e.g., backups/)` and no validation beyond `required`, so `/` is a plausible thing to type for "bucket root".

The fix trims slashes from both ends and treats an empty result as the bucket root:

```go
storagePath = strings.Trim(storagePath, "/")
if storagePath == "" {
    return filename
}
return storagePath + "/" + filename
```

All six existing test cases still pass unchanged, plus two new ones for `/` and `//`.

AI-assisted: written with Claude Code, reviewed and tested by me before sending.
