### PR TITLE
fix(nginx_log): logrotate dateext files become their own log group

### DIFF
--- a/internal/nginx_log/utils/log_rotation.go
+++ b/internal/nginx_log/utils/log_rotation.go
@@ -11,6 +11,7 @@ import (
 // and compiling regexes per call dominated the parse cost.
 var (
 	dotDateRotationRe  = regexp.MustCompile(`^\d{4}\.\d{2}\.\d{2}$`)
+	dashDateRotationRe = regexp.MustCompile(`^(.+\..+)-(\d{8}|\d{4}-\d{2}-\d{2})$`)
 	numberedRotationRe = regexp.MustCompile(`^(.+)\.(\d{1,3})$`)
 	middleNumberedRe   = regexp.MustCompile(`^(.+)\.(\d{1,3})\.log$`)
 	multiPartDateRe    = regexp.MustCompile(`^2\d{3}\.\d{2}\.\d{2}$`)
@@ -23,10 +24,10 @@ var (
 
 // MainLogPathFromFile extracts the main (base) log path from a file path,
 // collapsing rotated and compressed variants (access.log.1, access.log.2.gz,
-// access.log.20231201, ...) onto their log group base. This is the single
-// canonical implementation: the value is persisted as MainLogPath in the
-// index metadata and used for log group queries, so all grouping logic must
-// agree with it.
+// access.log.20231201, access.log-20231201, ...) onto their log group base.
+// This is the single canonical implementation: the value is persisted as
+// MainLogPath in the index metadata and used for log group queries, so all
+// grouping logic must agree with it.
 func MainLogPathFromFile(filePath string) string {
 	dir := filepath.Dir(filePath)
 	filename := filepath.Base(filePath)
@@ -34,6 +35,16 @@ func MainLogPathFromFile(filePath string) string {
 	// Remove compression extensions (.gz, .bz2, .xz, .lz4)
 	for _, ext := range []string{".gz", ".bz2", ".xz", ".lz4"} {
 		filename = strings.TrimSuffix(filename, ext)
+	}
+
+	// Handle dash-separated date rotation (access.log-20231201,
+	// access.log-2023-12-01). This is what logrotate writes with the `dateext`
+	// option, which is the default on Debian and Ubuntu, so it has to collapse
+	// onto the same group as the live log rather than becoming its own group.
+	// The base part must itself contain a dot so a plain name that merely ends
+	// in digits after a dash is left alone.
+	if match := dashDateRotationRe.FindStringSubmatch(filename); len(match) > 1 {
+		return filepath.Join(dir, match[1])
 	}
 
 	// Check if it's a dot-separated date rotation FIRST (access.log.YYYYMMDD or access.log.YYYY.MM.DD)

--- a/internal/nginx_log/utils/log_rotation_test.go
+++ b/internal/nginx_log/utils/log_rotation_test.go
@@ -26,6 +26,35 @@ func TestMainLogPathFromFile(t *testing.T) {
 	}
 }
 
+// TestMainLogPathFromFileDateExtRotation covers the file names logrotate writes
+// when the `dateext` option is enabled, which is the default on Debian and
+// Ubuntu. These have to collapse onto the same log group as the live log.
+func TestMainLogPathFromFileDateExtRotation(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"/var/log/nginx/access.log-20231201", "/var/log/nginx/access.log"},
+		{"/var/log/nginx/access.log-20231201.gz", "/var/log/nginx/access.log"},
+		{"/var/log/nginx/access.log-2023-12-01", "/var/log/nginx/access.log"},
+		{"/var/log/nginx/error.log-20231201.bz2", "/var/log/nginx/error.log"},
+		{"/var/log/nginx/example.com.access.log-20231201", "/var/log/nginx/example.com.access.log"},
+		// A name without a dotted suffix is not a rotated log: a site whose log
+		// is literally called "site-20231201" must stay its own group.
+		{"/var/log/nginx/site-20231201", "/var/log/nginx/site-20231201"},
+		// A dash followed by something that is not a full date is left alone.
+		{"/var/log/nginx/access.log-2023", "/var/log/nginx/access.log-2023"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			if got := MainLogPathFromFile(tc.input); got != tc.expected {
+				t.Errorf("MainLogPathFromFile(%s) = %s, want %s", tc.input, got, tc.expected)
+			}
+		})
+	}
+}
+
 func TestIsDatePattern(t *testing.T) {
 	testCases := []struct {
 		input    string


### PR DESCRIPTION
`MainLogPathFromFile` does not recognise logrotate's `dateext` names, so every rotated file becomes its own log group instead of collapsing onto `access.log`. The log list shows one bogus entry per rotation day, and that data is missing from the real group's analytics.

The two halves of the grouping disagree today. `ExpandLogGroupPath` globs `basePath + "*"`, so it already collects these files into the group, and then `MainLogPathFromFile` maps them back out:

```
glob collects these into the group:
                          before                      after
access.log             -> access.log              -> access.log
access.log-20260817    -> access.log-20260817     -> access.log
access.log-20260818.gz -> access.log-20260818.gz  -> access.log
access.log.1           -> access.log              -> access.log
```

`dateext` is the default on Debian and Ubuntu, so this is what the files look like out of the box there.

The pattern requires the base to contain a dot, so `access.log-20231201` collapses but a site log legitimately named `site-20231201` is left alone. A dash followed by something that is not a full date, like `access.log-2023`, is also left alone. Both cases are in the tests. The existing dot-separated forms are untouched.

AI-assisted: written with Claude Code, reviewed and tested by me before sending.
