### PR TITLE
fix(oidc): support Microsoft Entra ID GET redirect callback

### DIFF
--- a/api/user/oidc.go
+++ b/api/user/oidc.go
@@ -20,15 +20,22 @@ import (
 )
 
 type OIDCLoginUser struct {
-	Code  string `json:"code" binding:"required,max=255"`
-	State string `json:"state" binding:"required,max=255"`
+	Code  string `form:"code" json:"code" uri:"code" binding:"max=255"`
+	State string `form:"state" json:"state" uri:"state" binding:"max=255"`
 }
 
 func OIDCCallback(c *gin.Context) {
 	var loginUser OIDCLoginUser
 
-	ok := cosy.BindAndValid(c, &loginUser)
-	if !ok {
+	if err := c.ShouldBind(&loginUser); err != nil {
+		loginUser.Code = c.Query("code")
+		loginUser.State = c.Query("state")
+	}
+
+	if loginUser.Code == "" || loginUser.State == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "Missing code or state",
+		})
 		return
 	}
 

--- a/api/user/router.go
+++ b/api/user/router.go
@@ -17,6 +17,7 @@ func InitAuthRouter(r *gin.RouterGroup) {
 	r.POST("/casdoor_callback", CasdoorCallback)
 
 	r.GET("/oidc_uri", GetOIDCUri)
+	r.GET("/oidc_callback", OIDCCallback)
 	r.POST("/oidc_callback", OIDCCallback)
 
 	r.GET("/passkeys/config", GetPasskeyConfigStatus)


### PR DESCRIPTION
### Changes

1. Updated `router.go`
   - Added support for Microsoft Entra ID OIDC redirect callbacks using HTTP GET requests.

2. Updated `oidc.go`
   - Adapted OIDC callback handling to support GET-based redirect URLs.
   - Improved compatibility with Microsoft Entra ID OIDC authentication flow.

### Reason

Microsoft Entra ID uses an HTTP GET request for the OIDC redirect callback by default. The existing implementation did not properly handle GET-based OIDC callbacks.