### PR TITLE
feat(upgrade): support for HTTP proxy configuration

### DIFF
--- a/app.example.ini
+++ b/app.example.ini
@@ -52,6 +52,7 @@ Secret =
 
 [http]
 GithubProxy        = https://mirror.ghproxy.com/
+HTTPProxy          = http://proxy.example.com:8080
 InsecureSkipVerify = false
 WebSocketTrustedOrigins =
 

--- a/app/src/api/settings.ts
+++ b/app/src/api/settings.ts
@@ -51,6 +51,7 @@ export interface CertSettings {
 
 export interface HTTPSettings {
   github_proxy: string
+  http_proxy: string
   insecure_skip_verify: boolean
 }
 

--- a/app/src/views/preference/store/index.ts
+++ b/app/src/views/preference/store/index.ts
@@ -56,6 +56,7 @@ const useSystemSettingsStore = defineStore('systemSettings', () => {
     },
     http: {
       github_proxy: '',
+      http_proxy: '',
       insecure_skip_verify: false,
     },
     logrotate: {

--- a/app/src/views/preference/tabs/HTTPSettings.vue
+++ b/app/src/views/preference/tabs/HTTPSettings.vue
@@ -19,6 +19,18 @@ const { data, errors } = storeToRefs(systemSettingsStore)
         :placeholder="$gettext('For Chinese user: https://cloud.nginxui.com/')"
       />
     </AFormItem>
+    <AFormItem
+      :label="$gettext('HTTP Proxy')"
+      :validate-status="errors?.http?.http_proxy ? 'error' : ''"
+      :help="errors?.http?.http_proxy === 'url'
+        ? $gettext('The url is invalid')
+        : ''"
+    >
+      <AInput
+        v-model:value="data.http.http_proxy"
+        placeholder="http://127.0.0.1:8080"
+      />
+    </AFormItem>
     <AFormItem :label="$gettext('Insecure Skip Verify')">
       <ATag :color="data.http.insecure_skip_verify ? 'green' : 'red'">
         {{ data.http.insecure_skip_verify ? $gettext('Enabled') : $gettext('Disabled') }}

--- a/internal/upgrader/download_signature_test.go
+++ b/internal/upgrader/download_signature_test.go
@@ -70,12 +70,18 @@ func TestDownloadLatestReleaseVerifiesSignedArchivesThroughHTTPProxy(t *testing.
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			setTrustedMinisignKeysForTest(t, string(trustedPublicKeyText))
-			originalProxy := settings.HTTPSettings.GithubProxy
+			originalGithubProxy := settings.HTTPSettings.GithubProxy
+			originalHTTPProxy := settings.HTTPSettings.HTTPProxy
 			t.Cleanup(func() {
-				settings.HTTPSettings.GithubProxy = originalProxy
+				settings.HTTPSettings.GithubProxy = originalGithubProxy
+				settings.HTTPSettings.HTTPProxy = originalHTTPProxy
 			})
 
+			proxyRequests := 0
 			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				if strings.HasPrefix(request.RequestURI, "http://") {
+					proxyRequests++
+				}
 				switch {
 				case strings.HasSuffix(request.URL.Path, ".tar.gz.minisig"):
 					_, _ = writer.Write(testCase.signature)
@@ -90,6 +96,7 @@ func TestDownloadLatestReleaseVerifiesSignedArchivesThroughHTTPProxy(t *testing.
 			}))
 			defer server.Close()
 			settings.HTTPSettings.GithubProxy = server.URL
+			settings.HTTPSettings.HTTPProxy = server.URL
 
 			downloadDir := t.TempDir()
 			upgrader := newSignedDownloadTestUpgrader(downloadDir)
@@ -97,6 +104,7 @@ func TestDownloadLatestReleaseVerifiesSignedArchivesThroughHTTPProxy(t *testing.
 
 			if testCase.wantErr != nil {
 				assert.ErrorIs(t, downloadErr, testCase.wantErr)
+				assert.Positive(t, proxyRequests)
 				if archivePath != "" {
 					_, statErr := os.Stat(archivePath)
 					assert.ErrorIs(t, statErr, os.ErrNotExist)
@@ -107,6 +115,7 @@ func TestDownloadLatestReleaseVerifiesSignedArchivesThroughHTTPProxy(t *testing.
 			}
 
 			require.NoError(t, downloadErr)
+			assert.Equal(t, 3, proxyRequests)
 			t.Cleanup(func() {
 				_ = os.Remove(archivePath)
 				_ = os.Remove(archivePath + ".minisig")

--- a/internal/upgrader/upgrade.go
+++ b/internal/upgrader/upgrade.go
@@ -75,7 +75,10 @@ func (pw *ProgressWriter) Write(p []byte) (int, error) {
 }
 
 func downloadRelease(url string, dir string, progressChan chan float64) (tarName string, err error) {
-	client := &http.Client{}
+	client, err := version.NewHTTPClient()
+	if err != nil {
+		return
+	}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return
@@ -250,7 +253,11 @@ func (u *Upgrader) DownloadLatestRelease(progressChan chan float64) (tarName str
 }
 
 func downloadMetadata(url string, maxBytes int64) ([]byte, error) {
-	resp, err := http.Get(url)
+	client, err := version.NewHTTPClient()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/version/dev_build.go
+++ b/internal/version/dev_build.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"time"
 )
 
@@ -19,7 +18,11 @@ type TCommit struct {
 }
 
 func getDevBuild() (data TRelease, err error) {
-	resp, err := http.Get(GetGithubDevCommitAPIUrl())
+	client, err := NewHTTPClient()
+	if err != nil {
+		return
+	}
+	resp, err := client.Get(GetGithubDevCommitAPIUrl())
 	if err != nil {
 		return
 	}
@@ -40,7 +43,7 @@ func getDevBuild() (data TRelease, err error) {
 	}
 	shortSHA := commit.SHA[:7]
 
-	resp, err = http.Get(fmt.Sprintf("%sdev-builds", CloudflareWorkerAPI))
+	resp, err = client.Get(fmt.Sprintf("%sdev-builds", CloudflareWorkerAPI))
 	if err != nil {
 		return
 	}

--- a/internal/version/release.go
+++ b/internal/version/release.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/0xJacky/Nginx-UI/internal/transport"
+	"github.com/0xJacky/Nginx-UI/settings"
 	"github.com/pkg/errors"
 	"github.com/uozi-tech/cosy"
 )
@@ -43,8 +45,25 @@ func (t *TRelease) GetAssetsMap() (m map[string]TReleaseAsset) {
 	return
 }
 
+func NewHTTPClient() (*http.Client, error) {
+	if settings.HTTPSettings.HTTPProxy == "" {
+		return http.DefaultClient, nil
+	}
+
+	clientTransport, err := transport.NewTransport(transport.WithProxy(settings.HTTPSettings.HTTPProxy))
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Client{Transport: clientTransport}, nil
+}
+
 func getLatestRelease() (data TRelease, err error) {
-	resp, err := http.Get(GetGithubLatestReleaseAPIUrl())
+	client, err := NewHTTPClient()
+	if err != nil {
+		return
+	}
+	resp, err := client.Get(GetGithubLatestReleaseAPIUrl())
 	if err != nil {
 		err = errors.Wrap(err, "service.getLatestRelease http.Get err")
 		return
@@ -69,7 +88,11 @@ func getLatestRelease() (data TRelease, err error) {
 }
 
 func getLatestPrerelease() (data TRelease, err error) {
-	resp, err := http.Get(GetGithubReleasesListAPIUrl())
+	client, err := NewHTTPClient()
+	if err != nil {
+		return
+	}
+	resp, err := client.Get(GetGithubReleasesListAPIUrl())
 	if err != nil {
 		err = errors.Wrap(err, "service.getLatestPrerelease http.Get err")
 		return

--- a/settings/http.go
+++ b/settings/http.go
@@ -2,6 +2,7 @@ package settings
 
 type HTTP struct {
 	GithubProxy             string   `json:"github_proxy" binding:"omitempty,url"`
+	HTTPProxy               string   `json:"http_proxy" binding:"omitempty,url"`
 	InsecureSkipVerify      bool     `json:"insecure_skip_verify" protected:"true"`
 	WebSocketTrustedOrigins []string `json:"websocket_trusted_origins" binding:"omitempty,dive,url" env:"WEBSOCKET_TRUSTED_ORIGINS"`
 }

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -155,6 +155,7 @@ func TestSetup(t *testing.T) {
 
 	// Http
 	assert.Equal(t, "http://proxy.example.com", HTTPSettings.GithubProxy)
+	assert.Equal(t, "http://proxy.example.com:8080", HTTPSettings.HTTPProxy)
 	assert.Equal(t, true, HTTPSettings.InsecureSkipVerify)
 	assert.Equal(t, []string{"http://localhost:5173", "https://admin.example.com"}, HTTPSettings.WebSocketTrustedOrigins)
 


### PR DESCRIPTION
## Summary

Add HTTP proxy support for the upgrade workflow.

This feature is primarily intended for enterprise and intranet deployments where outbound access to release servers must be routed through a corporate HTTP proxy.

The proxy is configured in the `[http]` section of `app.ini`:

```ini
[http]
HTTPProxy = http://127.0.0.1:8080
```

When `HTTPProxy` is empty, the upgrade workflow preserves the existing behavior and uses Go's default HTTP client.

When `HTTPProxy` is configured, all upgrade-related outbound requests are routed through a custom HTTP client that uses the configured proxy.

## Changes

### Backend

- Add `HTTPProxy` to the HTTP settings configuration.
- Read and persist `HTTPProxy` from the `[http]` section.
- Create a proxy-aware HTTP client for upgrade-related requests.
- Preserve existing behavior when `HTTPProxy` is not configured.

### Configuration

Add `HTTPProxy` to:

- `app.ini`
- `app.example.ini`

Example:

```ini
[http]
HTTPProxy = http://127.0.0.1:8080
```

### Frontend

- Add an **HTTP Proxy** field to the HTTP settings page.
- Allow administrators to configure the upgrade proxy through the UI.

### Upgrade Workflow

Route the following requests through the configured HTTP proxy:

- Release metadata requests
- Prerelease metadata requests
- Development build metadata requests
- Upgrade archive downloads
- Archive signature downloads
- Archive digest downloads

When `HTTPProxy` is not configured, all requests continue to use the original implementation and Go's default HTTP client.

### Tests

Add tests to verify that the configured proxy is used for:

- Upgrade archive downloads
- Archive signature downloads
- Archive digest downloads

## Motivation

The previous proxy workaround relied on embedding environment-variable setup in the restart command. This approach has two issues.

### Restart command failures may be reported as successful

`cmd.Start()` only confirms that the child process was created.

A command can start successfully and then exit with a non-zero status. For example:

```bash
HTTP_PROXY=http://proxy.example.com:8080 ./nginx-ui
```

Without calling `cmd.Wait()`, the actual execution result is not captured and child processes may not be properly reaped.

The restart workflow should asynchronously wait for the spawned process and record its final exit status while preserving self-restart behavior.

### Restart commands may expose credentials

`Node.RestartCmd` can be logged verbatim and is not treated as sensitive by the Settings API.

If proxy credentials or other environment variables are embedded in the restart command, those values may be exposed through logs or API responses.

Moving proxy configuration into `[http].HTTPProxy` avoids placing sensitive information in restart commands and provides a safer and cleaner configuration model.

## Validation

- Verified that release metadata requests use the configured HTTP proxy.
- Verified that prerelease metadata requests use the configured HTTP proxy.
- Verified that development build metadata requests use the configured HTTP proxy.
- Verified that archive downloads use the configured HTTP proxy.
- Verified that signature downloads use the configured HTTP proxy.
- Verified that digest downloads use the configured HTTP proxy.
- Verified that the original behavior is preserved when `HTTPProxy` is empty.

## Notes for reviewers

- `messages.pot` was **not** regenerated as part of this PR. Running `bun run gettext:extract` on a Windows dev machine produces a diff spanning the entire file (line-ending/ordering differences unrelated to this change), so it can't be committed as a clean, reviewable patch from this environment. 