### PR TITLE
feat(maintenance): support custom maintenance pages per site

### DIFF
--- a/api/pages/maintenance.go
+++ b/api/pages/maintenance.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/0xJacky/Nginx-UI/settings"
@@ -101,13 +102,20 @@ func readMaintenanceTemplate(siteName string) []byte {
 	}
 
 	dir := settings.NginxSettings.GetMaintenanceDir()
-	candidates := make([]string, 0, 2)
+	names := make([]string, 0, 2)
 	if site := sanitizeMaintenanceFileName(siteName); site != "" {
-		candidates = append(candidates, filepath.Join(dir, site+"."+templateName))
+		names = append(names, site+"."+templateName)
 	}
-	candidates = append(candidates, filepath.Join(dir, templateName))
+	names = append(names, templateName)
 
-	for _, candidate := range candidates {
+	for _, name := range names {
+		// filepath.IsLocal rejects absolute paths and any ".." traversal, so the
+		// join below can never escape dir even if sanitizeMaintenanceFileName
+		// were bypassed.
+		if !filepath.IsLocal(name) {
+			continue
+		}
+		candidate := filepath.Join(dir, name)
 		if content, err := os.ReadFile(candidate); err == nil && len(content) > 0 {
 			return content
 		}
@@ -116,13 +124,17 @@ func readMaintenanceTemplate(siteName string) []byte {
 	return nil
 }
 
-// sanitizeMaintenanceFileName reduces the input to a single path element so that
-// neither the configured template name nor a spoofed site header can escape the
-// maintenance directory.
+// maintenanceFileNamePattern allows only characters that are safe in a single
+// path segment on every supported OS, closing off traversal and NUL-byte tricks.
+var maintenanceFileNamePattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+// sanitizeMaintenanceFileName reduces the input to a single, safe path element so
+// that neither the configured template name nor a spoofed site header can escape
+// the maintenance directory.
 func sanitizeMaintenanceFileName(name string) string {
 	name = strings.TrimSpace(name)
 	name = name[strings.LastIndexAny(name, `/\`)+1:]
-	if name == "." || name == ".." || strings.ContainsRune(name, 0) {
+	if name == "." || name == ".." || !maintenanceFileNamePattern.MatchString(name) {
 		return ""
 	}
 	return name

--- a/api/pages/maintenance.go
+++ b/api/pages/maintenance.go
@@ -15,7 +15,9 @@ import (
 //go:embed *.tmpl
 var tmplFS embed.FS
 
-const maintenanceMountDir = "/etc/nginx/maintenance"
+// maintenanceSiteHeader carries the site name injected by the generated
+// maintenance nginx configuration, so a per-site template can be selected.
+const maintenanceSiteHeader = "X-Maintenance-Site"
 
 // MaintenancePageData maintenance page data structure
 type MaintenancePageData struct {
@@ -57,15 +59,11 @@ func MaintenancePage(c *gin.Context) {
 		return
 	}
 
-	// Try custom mounted HTML first (NGINX_UI_NGINX_MAINTENANCE_TEMPLATE)
-	if name := strings.TrimSpace(settings.NginxSettings.MaintenanceTemplate); name != "" {
-		name = filepath.Base(name)
-		full := filepath.Join(maintenanceMountDir, name)
-
-		if b, err := os.ReadFile(full); err == nil && len(b) > 0 {
-			c.Data(http.StatusServiceUnavailable, "text/html; charset=utf-8", b)
-			return
-		}
+	// Try custom mounted HTML first (NGINX_UI_NGINX_MAINTENANCE_TEMPLATE),
+	// preferring the template dedicated to the requesting site.
+	if content := readMaintenanceTemplate(c.GetHeader(maintenanceSiteHeader)); content != nil {
+		c.Data(http.StatusServiceUnavailable, "text/html; charset=utf-8", content)
+		return
 	}
 
 	// Fallback: embedded template
@@ -90,4 +88,42 @@ func MaintenancePage(c *gin.Context) {
 // Helper function to check if a string contains a substring
 func contains(s, substr string) bool {
 	return strings.Contains(s, substr)
+}
+
+// readMaintenanceTemplate loads the custom maintenance page from the configured
+// maintenance directory. The site specific file "<site>.<template>" wins, and the
+// shared "<template>" file is used when it does not exist. A nil result means the
+// caller should fall back to the built-in generic maintenance page.
+func readMaintenanceTemplate(siteName string) []byte {
+	templateName := sanitizeMaintenanceFileName(settings.NginxSettings.MaintenanceTemplate)
+	if templateName == "" {
+		return nil
+	}
+
+	dir := settings.NginxSettings.GetMaintenanceDir()
+	candidates := make([]string, 0, 2)
+	if site := sanitizeMaintenanceFileName(siteName); site != "" {
+		candidates = append(candidates, filepath.Join(dir, site+"."+templateName))
+	}
+	candidates = append(candidates, filepath.Join(dir, templateName))
+
+	for _, candidate := range candidates {
+		if content, err := os.ReadFile(candidate); err == nil && len(content) > 0 {
+			return content
+		}
+	}
+
+	return nil
+}
+
+// sanitizeMaintenanceFileName reduces the input to a single path element so that
+// neither the configured template name nor a spoofed site header can escape the
+// maintenance directory.
+func sanitizeMaintenanceFileName(name string) string {
+	name = strings.TrimSpace(name)
+	name = name[strings.LastIndexAny(name, `/\`)+1:]
+	if name == "." || name == ".." || strings.ContainsRune(name, 0) {
+		return ""
+	}
+	return name
 }

--- a/api/pages/maintenance_test.go
+++ b/api/pages/maintenance_test.go
@@ -46,6 +46,7 @@ func TestReadMaintenanceTemplate(t *testing.T) {
 		{name: "missing site header falls back to generic", siteName: "", want: "generic"},
 		{name: "path traversal is stripped to the base name", siteName: "../../etc/example.com", want: "site"},
 		{name: "dot segment falls back to generic", siteName: "..", want: "generic"},
+		{name: "disallowed characters fall back to generic", siteName: "example.com; rm -rf", want: "generic"},
 	}
 
 	for _, test := range tests {
@@ -70,5 +71,29 @@ func TestGetMaintenanceDirFallsBackToDefault(t *testing.T) {
 
 	if got := settings.NginxSettings.GetMaintenanceDir(); got != settings.DefaultMaintenanceDir {
 		t.Fatalf("GetMaintenanceDir() = %q, want %q", got, settings.DefaultMaintenanceDir)
+	}
+}
+
+func TestSanitizeMaintenanceFileNameRejectsTraversal(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "plain name", input: "maintenance.html", want: "maintenance.html"},
+		{name: "absolute posix path", input: "/etc/passwd", want: "passwd"},
+		{name: "absolute windows path", input: `C:\Windows\System32\config`, want: "config"},
+		{name: "traversal", input: "..", want: ""},
+		{name: "nul byte", input: "maintenance.html\x00.png", want: ""},
+		{name: "shell metacharacters", input: "a;b", want: ""},
+		{name: "space", input: "a b", want: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := sanitizeMaintenanceFileName(test.input); got != test.want {
+				t.Fatalf("sanitizeMaintenanceFileName(%q) = %q, want %q", test.input, got, test.want)
+			}
+		})
 	}
 }

--- a/api/pages/maintenance_test.go
+++ b/api/pages/maintenance_test.go
@@ -1,0 +1,74 @@
+package pages
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/0xJacky/Nginx-UI/settings"
+)
+
+func setupMaintenanceTemplateSettings(t *testing.T, dir, template string) {
+	t.Helper()
+	originalDir := settings.NginxSettings.MaintenanceDir
+	originalTemplate := settings.NginxSettings.MaintenanceTemplate
+	t.Cleanup(func() {
+		settings.NginxSettings.MaintenanceDir = originalDir
+		settings.NginxSettings.MaintenanceTemplate = originalTemplate
+	})
+
+	settings.NginxSettings.MaintenanceDir = dir
+	settings.NginxSettings.MaintenanceTemplate = template
+}
+
+func TestReadMaintenanceTemplate(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "maintenance.html"), []byte("generic"), 0644); err != nil {
+		t.Fatalf("failed to write generic template: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "example.com.maintenance.html"), []byte("site"), 0644); err != nil {
+		t.Fatalf("failed to write site template: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "empty.com.maintenance.html"), nil, 0644); err != nil {
+		t.Fatalf("failed to write empty site template: %v", err)
+	}
+
+	setupMaintenanceTemplateSettings(t, dir, "maintenance.html")
+
+	tests := []struct {
+		name     string
+		siteName string
+		want     string
+	}{
+		{name: "site specific template wins", siteName: "example.com", want: "site"},
+		{name: "unknown site falls back to generic", siteName: "unknown.com", want: "generic"},
+		{name: "empty site template falls back to generic", siteName: "empty.com", want: "generic"},
+		{name: "missing site header falls back to generic", siteName: "", want: "generic"},
+		{name: "path traversal is stripped to the base name", siteName: "../../etc/example.com", want: "site"},
+		{name: "dot segment falls back to generic", siteName: "..", want: "generic"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := string(readMaintenanceTemplate(test.siteName)); got != test.want {
+				t.Fatalf("readMaintenanceTemplate(%q) = %q, want %q", test.siteName, got, test.want)
+			}
+		})
+	}
+}
+
+func TestReadMaintenanceTemplateWithoutConfiguredTemplate(t *testing.T) {
+	setupMaintenanceTemplateSettings(t, t.TempDir(), "")
+
+	if content := readMaintenanceTemplate("example.com"); content != nil {
+		t.Fatalf("readMaintenanceTemplate() = %q, want nil so the built-in page is used", content)
+	}
+}
+
+func TestGetMaintenanceDirFallsBackToDefault(t *testing.T) {
+	setupMaintenanceTemplateSettings(t, "", "maintenance.html")
+
+	if got := settings.NginxSettings.GetMaintenanceDir(); got != settings.DefaultMaintenanceDir {
+		t.Fatalf("GetMaintenanceDir() = %q, want %q", got, settings.DefaultMaintenanceDir)
+	}
+}

--- a/api/settings/settings.go
+++ b/api/settings/settings.go
@@ -233,6 +233,7 @@ func buildNginxSettingsResponse() gin.H {
 	response["config_dir"] = nginx.GetConfPath()
 	response["pid_path"] = nginx.GetPIDPath()
 	response["stub_status_port"] = settings.NginxSettings.GetStubStatusPort()
+	response["maintenance_dir"] = settings.NginxSettings.GetMaintenanceDir()
 
 	if settings.NginxSettings.ReloadCmd == "" {
 		response["reload_cmd"] = "nginx -s reload"

--- a/api/sites/security_test.go
+++ b/api/sites/security_test.go
@@ -107,3 +107,61 @@ func TestEnableMaintenanceSiteRejectsInvalidSiteName(t *testing.T) {
 		t.Fatalf("expected invalid site name response, got %q", recorder.Body.String())
 	}
 }
+
+func TestGetSiteRejectsInvalidSiteName(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Params = gin.Params{{Key: "name", Value: "..%2F..%2Fnginx.conf"}}
+
+	GetSite(c)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d with body %q", recorder.Code, recorder.Body.String())
+	}
+	if !bytes.Contains(recorder.Body.Bytes(), []byte("invalid site name")) {
+		t.Fatalf("expected invalid site name response, got %q", recorder.Body.String())
+	}
+}
+
+func TestDeleteSiteRejectsInvalidSiteName(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Params = gin.Params{{Key: "name", Value: "..%2F..%2Fnginx.conf"}}
+
+	DeleteSite(c)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d with body %q", recorder.Code, recorder.Body.String())
+	}
+	if !bytes.Contains(recorder.Body.Bytes(), []byte("invalid site name")) {
+		t.Fatalf("expected invalid site name response, got %q", recorder.Body.String())
+	}
+}
+
+func TestRenameSiteRejectsInvalidNewName(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("sites/:name/rename", RenameSite)
+
+	body, err := json.Marshal(gin.H{
+		"new_name": "../../etc/passwd",
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal request body: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/sites/example.com/rename", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d with body %q", recorder.Code, recorder.Body.String())
+	}
+	if !bytes.Contains(recorder.Body.Bytes(), []byte("invalid site name")) {
+		t.Fatalf("expected invalid site name response, got %q", recorder.Body.String())
+	}
+}

--- a/api/sites/site.go
+++ b/api/sites/site.go
@@ -143,6 +143,9 @@ func setSiteDNSRecords(siteModel *model.Site, domainID *int, records []model.Sit
 
 func GetSite(c *gin.Context) {
 	name := helper.UnescapeURL(c.Param("name"))
+	if rejectInvalidSiteName(c, name) {
+		return
+	}
 
 	path, err := site.ResolveAvailablePath(name)
 	if err != nil {
@@ -237,6 +240,9 @@ func GetSite(c *gin.Context) {
 
 func SaveSite(c *gin.Context) {
 	name := helper.UnescapeURL(c.Param("name"))
+	if rejectInvalidSiteName(c, name) {
+		return
+	}
 
 	var json struct {
 		Content       string                 `json:"content" binding:"required"`
@@ -310,10 +316,17 @@ func SaveSite(c *gin.Context) {
 
 func RenameSite(c *gin.Context) {
 	oldName := helper.UnescapeURL(c.Param("name"))
+	if rejectInvalidSiteName(c, oldName) {
+		return
+	}
+
 	var json struct {
 		NewName string `json:"new_name"`
 	}
 	if !cosy.BindAndValid(c, &json) {
+		return
+	}
+	if rejectInvalidSiteName(c, json.NewName) {
 		return
 	}
 
@@ -330,7 +343,7 @@ func RenameSite(c *gin.Context) {
 
 func disableMaintenanceIfExists(name string) error {
 	// Check if the site is in maintenance mode, if yes, disable maintenance mode first
-	maintenanceConfigPath, err := site.ResolveEnabledPath(name + site.MaintenanceSuffix)
+	maintenanceConfigPath, err := site.ResolveEnabledMaintenancePath(name)
 	if err != nil {
 		return err
 	}
@@ -364,6 +377,9 @@ func disableSiteByName(name string) error {
 
 func EnableSite(c *gin.Context) {
 	name := helper.UnescapeURL(c.Param("name"))
+	if rejectInvalidSiteName(c, name) {
+		return
+	}
 
 	err := enableSiteByName(name)
 	if err != nil {
@@ -378,6 +394,9 @@ func EnableSite(c *gin.Context) {
 
 func DisableSite(c *gin.Context) {
 	name := helper.UnescapeURL(c.Param("name"))
+	if rejectInvalidSiteName(c, name) {
+		return
+	}
 
 	err := disableSiteByName(name)
 	if err != nil {
@@ -401,6 +420,9 @@ func BatchEnableSites(c *gin.Context) {
 	}
 
 	for _, name := range json.Names {
+		if rejectInvalidSiteName(c, name) {
+			return
+		}
 		if err := enableSiteByName(name); err != nil {
 			cosy.ErrHandler(c, err)
 			return
@@ -419,6 +441,9 @@ func BatchDisableSites(c *gin.Context) {
 	}
 
 	for _, name := range json.Names {
+		if rejectInvalidSiteName(c, name) {
+			return
+		}
 		if err := disableSiteByName(name); err != nil {
 			cosy.ErrHandler(c, err)
 			return
@@ -431,7 +456,12 @@ func BatchDisableSites(c *gin.Context) {
 }
 
 func DeleteSite(c *gin.Context) {
-	err := site.Delete(helper.UnescapeURL(c.Param("name")))
+	name := helper.UnescapeURL(c.Param("name"))
+	if rejectInvalidSiteName(c, name) {
+		return
+	}
+
+	err := site.Delete(name)
 	if err != nil {
 		cosy.ErrHandler(c, err)
 		return
@@ -478,12 +508,21 @@ func isInvalidSiteName(name string) bool {
 		strings.ContainsAny(name, `/\`) || strings.Contains(name, "..")
 }
 
+// rejectInvalidSiteName responds with 400 and reports whether name failed
+// validation, so callers can bail out before it reaches any path expression.
+func rejectInvalidSiteName(c *gin.Context, name string) bool {
+	if !isInvalidSiteName(name) {
+		return false
+	}
+	c.JSON(http.StatusBadRequest, gin.H{
+		"message": "invalid site name",
+	})
+	return true
+}
+
 func EnableMaintenanceSite(c *gin.Context) {
 	name := helper.UnescapeURL(c.Param("name"))
-	if isInvalidSiteName(name) {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": "invalid site name",
-		})
+	if rejectInvalidSiteName(c, name) {
 		return
 	}
 

--- a/app.example.ini
+++ b/app.example.ini
@@ -70,6 +70,8 @@ PIDPath         =
 TestConfigCmd   =
 ReloadCmd       = nginx -s reload
 RestartCmd      = start-stop-daemon --start --quiet --pidfile /var/run/nginx.pid --exec /usr/sbin/nginx
+; Directory that custom maintenance page templates are loaded from.
+MaintenanceDir  = /etc/nginx/maintenance
 
 [nginx_log]
 ; Enable or disable nginx access log indexing and analytics.

--- a/app/src/api/settings.ts
+++ b/app/src/api/settings.ts
@@ -84,6 +84,7 @@ export interface NginxSettings {
   restart_cmd: string
   stub_status_port: number
   container_name: string
+  maintenance_dir?: string
   maintenance_template?: string
 }
 

--- a/app/src/language/zh_CN.po
+++ b/app/src/language/zh_CN.po
@@ -8656,6 +8656,10 @@ msgid "Mounted directory"
 msgstr "挂载目录"
 
 #: src/views/preference/tabs/NginxSettings.vue:22
+msgid "The file named <site name>.<filename> is used first; if it does not exist, the generic <filename> is used; if neither exists, the built-in Nginx UI maintenance page is used."
+msgstr "优先使用 <站点名>.<文件名> 命名的文件，若不存在则降级使用通用的 <文件名>，若两者均不存在则降级使用 Nginx UI 内置的维护页面。"
+
+#: src/views/preference/tabs/NginxSettings.vue:25
 msgid "Nginx Access Log Path"
 msgstr "Nginx 访问日志路径"
 

--- a/app/src/language/zh_TW.po
+++ b/app/src/language/zh_TW.po
@@ -8661,6 +8661,10 @@ msgid "Mounted directory"
 msgstr "掛載目錄"
 
 #: src/views/preference/tabs/NginxSettings.vue:22
+msgid "The file named <site name>.<filename> is used first; if it does not exist, the generic <filename> is used; if neither exists, the built-in Nginx UI maintenance page is used."
+msgstr "優先使用 <站台名稱>.<檔案名稱> 命名的檔案，若不存在則降級使用通用的 <檔案名稱>，若兩者均不存在則降級使用 Nginx UI 內建的維護頁面。"
+
+#: src/views/preference/tabs/NginxSettings.vue:25
 msgid "Nginx Access Log Path"
 msgstr "Nginx 存取日誌路徑"
 

--- a/app/src/views/preference/tabs/NginxSettings.vue
+++ b/app/src/views/preference/tabs/NginxSettings.vue
@@ -19,7 +19,7 @@ const { data } = storeToRefs(systemSettingsStore)
         {{ $gettext('Mounted directory') }}: {{ data.nginx.maintenance_dir }}
       </div>
       <div class="text-secondary mt-1">
-        {{ $gettext('The file named <site name>.<filename> is used first, otherwise the generic file is used.') }}
+        {{ $gettext('The file named <site name>.<filename> is used first; if it does not exist, the generic <filename> is used; if neither exists, the built-in Nginx UI maintenance page is used.') }}
       </div>
     </AFormItem>
     <AFormItem :label="$gettext('Nginx Access Log Path')">

--- a/app/src/views/preference/tabs/NginxSettings.vue
+++ b/app/src/views/preference/tabs/NginxSettings.vue
@@ -16,7 +16,10 @@ const { data } = storeToRefs(systemSettingsStore)
         :placeholder="$gettext('maintenance.html')"
       />
       <div class="text-secondary mt-1">
-        {{ $gettext('Mounted directory') }}: /etc/nginx/maintenance
+        {{ $gettext('Mounted directory') }}: {{ data.nginx.maintenance_dir }}
+      </div>
+      <div class="text-secondary mt-1">
+        {{ $gettext('The file named <site name>.<filename> is used first, otherwise the generic file is used.') }}
       </div>
     </AFormItem>
     <AFormItem :label="$gettext('Nginx Access Log Path')">

--- a/docs/guide/config-nginx.md
+++ b/docs/guide/config-nginx.md
@@ -130,6 +130,13 @@ Make sure the port you set is not being used by other services.
 
 ## Maintenance Page
 
+### MaintenanceDir
+- Type: `string`
+- Default: `/etc/nginx/maintenance`
+- Environment Variable: `NGINX_UI_NGINX_MAINTENANCE_DIR`
+
+This option is used to set the directory that Nginx UI reads custom maintenance page templates from. If it is empty, `/etc/nginx/maintenance` is used.
+
 ### MaintenanceTemplate
 - Type: `string`
 - Environment Variable: `NGINX_UI_NGINX_MAINTENANCE_TEMPLATE`
@@ -137,11 +144,16 @@ Make sure the port you set is not being used by other services.
 
 This option is used to select a custom HTML template for the Nginx UI maintenance page. You can set it through the environment variable or in Settings > Nginx.
 
-Only the file name is used. Nginx UI loads the custom template from `/etc/nginx/maintenance/<filename>`, and path components in the configured value are ignored.
+Only the file name is used. Path components in the configured value are ignored, and the template is loaded from the maintenance directory in the following order:
 
-If this option is empty, the file cannot be read, or the file is empty, Nginx UI falls back to the built-in maintenance page template.
+1. `<MaintenanceDir>/<site name>.<filename>`, the template dedicated to the site under maintenance;
+2. `<MaintenanceDir>/<filename>`, the generic template shared by all sites.
 
-For Docker deployments, mount a host directory to `/etc/nginx/maintenance` and put your template file there:
+For example, with `MaintenanceTemplate=maintenance.html`, the site `example.com` first tries `/etc/nginx/maintenance/example.com.maintenance.html`, then falls back to `/etc/nginx/maintenance/maintenance.html`.
+
+If this option is empty, no file can be read, or the files are empty, Nginx UI falls back to the built-in maintenance page template.
+
+For Docker deployments, mount a host directory to the maintenance directory and put your template files there:
 
 ```yaml
 services:

--- a/docs/guide/env.md
+++ b/docs/guide/env.md
@@ -75,7 +75,9 @@ Applicable for version v2.0.0-beta.37 and above.
 | Configuration Setting | Environment Variable               |
 |-----------------------|------------------------------------|
 | GithubProxy           | NGINX_UI_HTTP_GITHUB_PROXY         |
+| HTTPProxy             | NGINX_UI_HTTP_HTTP_PROXY           |
 | InsecureSkipVerify    | NGINX_UI_HTTP_INSECURE_SKIP_VERIFY |
+| WebSocketTrustedOrigins | NGINX_UI_HTTP_WEBSOCKET_TRUSTED_ORIGINS |
 
 ## Logrotate
 | Configuration Setting | Environment Variable        |
@@ -98,6 +100,7 @@ Applicable for version v2.0.0-beta.37 and above.
 | LogDirWhiteList       | NGINX_UI_NGINX_LOG_DIR_WHITE_LIST |
 | StubStatusPort        | NGINX_UI_NGINX_STUB_STATUS_PORT   |
 | ContainerName         | NGINX_UI_NGINX_CONTAINER_NAME     |
+| MaintenanceDir        | NGINX_UI_NGINX_MAINTENANCE_DIR    |
 | MaintenanceTemplate   | NGINX_UI_NGINX_MAINTENANCE_TEMPLATE |
 
 ## Nginx Log

--- a/docs/zh_CN/guide/config-nginx.md
+++ b/docs/zh_CN/guide/config-nginx.md
@@ -131,6 +131,13 @@ start-stop-daemon --start --quiet --pidfile $PID --exec $SBIN_PATH
 
 ## 维护页面
 
+### MaintenanceDir
+- 类型：`string`
+- 默认值：`/etc/nginx/maintenance`
+- 环境变量：`NGINX_UI_NGINX_MAINTENANCE_DIR`
+
+此选项用于设置 Nginx UI 读取自定义维护页面模板的目录。若留空，则使用 `/etc/nginx/maintenance`。
+
 ### MaintenanceTemplate
 - 类型：`string`
 - 环境变量：`NGINX_UI_NGINX_MAINTENANCE_TEMPLATE`
@@ -138,11 +145,16 @@ start-stop-daemon --start --quiet --pidfile $PID --exec $SBIN_PATH
 
 此选项用于为 Nginx UI 维护页面选择自定义 HTML 模板。您可以通过环境变量设置，也可以在 Settings > Nginx 中设置。
 
-此配置只使用文件名。Nginx UI 会从 `/etc/nginx/maintenance/<filename>` 加载自定义模板，配置值中的路径部分会被忽略。
+此配置只使用文件名，配置值中的路径部分会被忽略。Nginx UI 按以下顺序从维护目录加载模板：
+
+1. `<MaintenanceDir>/<站点名称>.<文件名>`，即该站点专属的模板；
+2. `<MaintenanceDir>/<文件名>`，即所有站点共用的通用模板。
+
+例如当 `MaintenanceTemplate=maintenance.html` 时，站点 `example.com` 会优先尝试 `/etc/nginx/maintenance/example.com.maintenance.html`，匹配不到时降级为 `/etc/nginx/maintenance/maintenance.html`。
 
 如果此选项为空、文件不可读或文件内容为空，Nginx UI 将回退到内置维护页面模板。
 
-对于 Docker 部署，请将宿主机目录挂载到 `/etc/nginx/maintenance`，并将模板文件放在该目录中：
+对于 Docker 部署，请将宿主机目录挂载到维护目录，并将模板文件放在该目录中：
 
 ```yaml
 services:

--- a/docs/zh_CN/guide/env.md
+++ b/docs/zh_CN/guide/env.md
@@ -84,7 +84,9 @@
 | 配置                 | 环境变量                               |
 |--------------------|------------------------------------|
 | GithubProxy        | NGINX_UI_HTTP_GITHUB_PROXY         |
+| HTTPProxy          | NGINX_UI_HTTP_HTTP_PROXY           |
 | InsecureSkipVerify | NGINX_UI_HTTP_INSECURE_SKIP_VERIFY |
+| WebSocketTrustedOrigins | NGINX_UI_HTTP_WEBSOCKET_TRUSTED_ORIGINS |
 
 ## Logrotate
 
@@ -109,6 +111,7 @@
 | LogDirWhiteList | NGINX_UI_NGINX_LOG_DIR_WHITE_LIST |
 | StubStatusPort  | NGINX_UI_NGINX_STUB_STATUS_PORT   |
 | ContainerName   | NGINX_UI_NGINX_CONTAINER_NAME     |
+| MaintenanceDir  | NGINX_UI_NGINX_MAINTENANCE_DIR    |
 | MaintenanceTemplate | NGINX_UI_NGINX_MAINTENANCE_TEMPLATE |
 
 ## Nginx Log

--- a/docs/zh_TW/guide/config-nginx.md
+++ b/docs/zh_TW/guide/config-nginx.md
@@ -124,6 +124,13 @@ start-stop-daemon --start --quiet --pidfile $PID --exec $SBIN_PATH
 
 ## 維護頁面
 
+### MaintenanceDir
+- 類型：`string`
+- 預設值：`/etc/nginx/maintenance`
+- 環境變數：`NGINX_UI_NGINX_MAINTENANCE_DIR`
+
+此選項用於設定 Nginx UI 讀取自訂維護頁面模板的目錄。若留空，則使用 `/etc/nginx/maintenance`。
+
 ### MaintenanceTemplate
 - 類型：`string`
 - 環境變數：`NGINX_UI_NGINX_MAINTENANCE_TEMPLATE`
@@ -131,11 +138,16 @@ start-stop-daemon --start --quiet --pidfile $PID --exec $SBIN_PATH
 
 此選項用於為 Nginx UI 維護頁面選擇自訂 HTML 模板。您可以透過環境變數設定，也可以在 Settings > Nginx 中設定。
 
-此設定只使用檔案名稱。Nginx UI 會從 `/etc/nginx/maintenance/<filename>` 載入自訂模板，設定值中的路徑部分會被忽略。
+此設定只使用檔案名稱，設定值中的路徑部分會被忽略。Nginx UI 會依下列順序從維護目錄載入模板：
+
+1. `<MaintenanceDir>/<站台名稱>.<檔案名稱>`，即該站台專屬的模板；
+2. `<MaintenanceDir>/<檔案名稱>`，即所有站台共用的通用模板。
+
+例如當 `MaintenanceTemplate=maintenance.html` 時，站台 `example.com` 會優先嘗試 `/etc/nginx/maintenance/example.com.maintenance.html`，找不到時降級為 `/etc/nginx/maintenance/maintenance.html`。
 
 如果此選項為空、檔案不可讀或檔案內容為空，Nginx UI 將回退到內建維護頁面模板。
 
-對於 Docker 部署，請將主機目錄掛載到 `/etc/nginx/maintenance`，並將模板檔案放在該目錄中：
+對於 Docker 部署，請將主機目錄掛載到維護目錄，並將模板檔案放在該目錄中：
 
 ```yaml
 services:

--- a/docs/zh_TW/guide/env.md
+++ b/docs/zh_TW/guide/env.md
@@ -84,7 +84,9 @@
 | 設定                 | 環境變數                               |
 |--------------------|------------------------------------|
 | GithubProxy        | NGINX_UI_HTTP_GITHUB_PROXY         |
+| HTTPProxy          | NGINX_UI_HTTP_HTTP_PROXY           |
 | InsecureSkipVerify | NGINX_UI_HTTP_INSECURE_SKIP_VERIFY |
+| WebSocketTrustedOrigins | NGINX_UI_HTTP_WEBSOCKET_TRUSTED_ORIGINS |
 
 ## Logrotate
 
@@ -109,6 +111,7 @@
 | LogDirWhiteList | NGINX_UI_NGINX_LOG_DIR_WHITE_LIST |
 | StubStatusPort  | NGINX_UI_NGINX_STUB_STATUS_PORT   |
 | ContainerName   | NGINX_UI_NGINX_CONTAINER_NAME     |
+| MaintenanceDir  | NGINX_UI_NGINX_MAINTENANCE_DIR    |
 | MaintenanceTemplate | NGINX_UI_NGINX_MAINTENANCE_TEMPLATE |
 
 ## Nginx Log

--- a/internal/config/generic_list.go
+++ b/internal/config/generic_list.go
@@ -256,12 +256,14 @@ func SiteStatusMapBuilder(maintenanceSuffix string) StatusMapBuilder {
 
 		// Update enabled and maintenance status
 		for _, enabledSite := range enabledConfig {
-			name := enabledSite.Name()
+			// Strip the platform symlink suffix first (e.g. the trailing ".conf"
+			// Windows setups need), otherwise the maintenance suffix never matches.
+			name := nginx.GetConfNameBySymlinkName(enabledSite.Name())
 			if strings.HasSuffix(name, maintenanceSuffix) {
 				originalName := strings.TrimSuffix(name, maintenanceSuffix)
 				statusMap[originalName] = StatusMaintenance
 			} else {
-				statusMap[nginx.GetConfNameBySymlinkName(name)] = StatusEnabled
+				statusMap[name] = StatusEnabled
 			}
 		}
 

--- a/internal/config/generic_list_test.go
+++ b/internal/config/generic_list_test.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/0xJacky/Nginx-UI/internal/nginx"
+)
+
+// TestSiteStatusMapBuilderDetectsPlatformMaintenanceSuffix reproduces the
+// Windows-specific bug where the maintenance suffix check ran before the
+// platform symlink suffix (".conf" on Windows) was stripped, so a maintenance
+// config such as "example.com_nginx_ui_maintenance.conf" was reported as
+// enabled instead of in maintenance. Building the enabled file name through
+// nginx.GetConfSymlinkPath, exactly like production code does, keeps this test
+// meaningful on every platform.
+func TestSiteStatusMapBuilderDetectsPlatformMaintenanceSuffix(t *testing.T) {
+	const maintenanceSuffix = "_nginx_ui_maintenance"
+	dir := t.TempDir()
+
+	availableName := "example.com"
+	if err := os.WriteFile(filepath.Join(dir, availableName), []byte("server {}\n"), 0o644); err != nil {
+		t.Fatalf("failed to write available config: %v", err)
+	}
+
+	enabledName := nginx.GetConfSymlinkPath(availableName + maintenanceSuffix)
+	if err := os.WriteFile(filepath.Join(dir, enabledName), []byte("server {}\n"), 0o644); err != nil {
+		t.Fatalf("failed to write enabled maintenance config: %v", err)
+	}
+
+	configFiles, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to read available dir: %v", err)
+	}
+	enabledConfig, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to read enabled dir: %v", err)
+	}
+	// Only the maintenance file represents "enabled" entries here.
+	var maintenanceEntries []os.DirEntry
+	for _, entry := range enabledConfig {
+		if entry.Name() == enabledName {
+			maintenanceEntries = append(maintenanceEntries, entry)
+		}
+	}
+
+	statusMap := SiteStatusMapBuilder(maintenanceSuffix)(configFiles, maintenanceEntries)
+
+	if got := statusMap[availableName]; got != StatusMaintenance {
+		t.Fatalf("statusMap[%q] = %q, want %q", availableName, got, StatusMaintenance)
+	}
+}

--- a/internal/site/certificate_migration.go
+++ b/internal/site/certificate_migration.go
@@ -432,7 +432,7 @@ func certificateDeploymentConfigPaths(name string) ([]string, error) {
 	}
 	paths := []string{availablePath}
 	if status == StatusMaintenance {
-		maintenancePath, resolveErr := ResolveEnabledPath(name + MaintenanceSuffix)
+		maintenancePath, resolveErr := resolveEnabledMaintenancePath(name)
 		if resolveErr != nil {
 			return nil, resolveErr
 		}

--- a/internal/site/certificate_migration.go
+++ b/internal/site/certificate_migration.go
@@ -432,7 +432,7 @@ func certificateDeploymentConfigPaths(name string) ([]string, error) {
 	}
 	paths := []string{availablePath}
 	if status == StatusMaintenance {
-		maintenancePath, resolveErr := resolveEnabledMaintenancePath(name)
+		maintenancePath, resolveErr := ResolveEnabledMaintenancePath(name)
 		if resolveErr != nil {
 			return nil, resolveErr
 		}

--- a/internal/site/deploy.go
+++ b/internal/site/deploy.go
@@ -83,7 +83,7 @@ func detachFromLocalNginx(name string) error {
 		return err
 	}
 
-	maintenancePath, err := ResolveEnabledPath(name + MaintenanceSuffix)
+	maintenancePath, err := resolveEnabledMaintenancePath(name)
 	if err != nil {
 		return err
 	}

--- a/internal/site/deploy.go
+++ b/internal/site/deploy.go
@@ -83,7 +83,7 @@ func detachFromLocalNginx(name string) error {
 		return err
 	}
 
-	maintenancePath, err := resolveEnabledMaintenancePath(name)
+	maintenancePath, err := ResolveEnabledMaintenancePath(name)
 	if err != nil {
 		return err
 	}

--- a/internal/site/maintenance.go
+++ b/internal/site/maintenance.go
@@ -52,6 +52,10 @@ type maintenanceIncludeExpander struct {
 
 // EnableMaintenance enables maintenance mode for a site
 func EnableMaintenance(name string) (err error) {
+	if err = validateSiteName(name); err != nil {
+		return err
+	}
+
 	// Check if the site exists in sites-available
 	configFilePath, err := ResolveAvailablePath(name)
 	if err != nil {
@@ -62,7 +66,7 @@ func EnableMaintenance(name string) (err error) {
 	}
 
 	// Path for the maintenance configuration file
-	maintenanceConfigPath, err := resolveEnabledMaintenancePath(name)
+	maintenanceConfigPath, err := ResolveEnabledMaintenancePath(name)
 	if err != nil {
 		return err
 	}
@@ -155,6 +159,10 @@ func EnableMaintenance(name string) (err error) {
 
 // DisableMaintenance disables maintenance mode for a site
 func DisableMaintenance(name string) (err error) {
+	if err = validateSiteName(name); err != nil {
+		return err
+	}
+
 	// Remote namespaces have no local maintenance configuration to restore.
 	if IsRemoteDeploy(name) {
 		go syncDisableMaintenance(name)
@@ -163,7 +171,7 @@ func DisableMaintenance(name string) (err error) {
 	}
 
 	// Check if the site is in maintenance mode
-	maintenanceConfigPath, err := resolveEnabledMaintenancePath(name)
+	maintenanceConfigPath, err := ResolveEnabledMaintenancePath(name)
 	if err != nil {
 		return err
 	}
@@ -221,6 +229,12 @@ func DisableMaintenance(name string) (err error) {
 	// Reload nginx
 	res = nginx.Control(nginx.Reload)
 	if res.IsError() {
+		// Reload failed after the config already tested clean: restore the
+		// maintenance file and drop the new symlink so Nginx keeps serving
+		// what it actually reloaded, then reload again to reconcile.
+		_ = os.Remove(enabledConfigFilePath)
+		_ = os.WriteFile(maintenanceConfigPath, maintenanceContent, 0644)
+		nginx.Control(nginx.Reload)
 		return res.GetError()
 	}
 

--- a/internal/site/maintenance.go
+++ b/internal/site/maintenance.go
@@ -60,13 +60,13 @@ func EnableMaintenance(name string) (err error) {
 	}
 
 	// Path for the maintenance configuration file
-	maintenanceConfigPath, err := ResolveEnabledPath(name + MaintenanceSuffix)
+	maintenanceConfigPath, err := resolveEnabledMaintenancePath(name)
 	if err != nil {
 		return err
 	}
 
 	// Path for original configuration in sites-enabled
-	originalEnabledPath, err := ResolveEnabledPath(name)
+	originalEnabledPath, err := resolveEnabledSymlinkPath(name)
 	if err != nil {
 		return err
 	}
@@ -98,7 +98,7 @@ func EnableMaintenance(name string) (err error) {
 	}
 
 	// Create new maintenance configuration
-	maintenanceConfig := createMaintenanceConfig(conf, filepath.Dir(configFilePath))
+	maintenanceConfig := createMaintenanceConfig(conf, filepath.Dir(configFilePath), name)
 
 	// Write maintenance configuration to file
 	err = os.WriteFile(maintenanceConfigPath, []byte(maintenanceConfig), 0644)
@@ -107,7 +107,8 @@ func EnableMaintenance(name string) (err error) {
 	}
 
 	// Remove the original symlink from sites-enabled if it exists
-	if helper.FileExists(originalEnabledPath) {
+	originalWasEnabled := helper.FileExists(originalEnabledPath)
+	if originalWasEnabled {
 		err = os.Remove(originalEnabledPath)
 		if err != nil {
 			// If we couldn't remove the original, remove the maintenance file and return the error
@@ -116,20 +117,31 @@ func EnableMaintenance(name string) (err error) {
 		}
 	}
 
+	// revertMaintenance drops the maintenance config and re-enables the original
+	// site, so a failed switch never leaves the site without any enabled config.
+	revertMaintenance := func() {
+		_ = os.Remove(maintenanceConfigPath)
+		if !originalWasEnabled {
+			return
+		}
+		if symlinkErr := os.Symlink(configFilePath, originalEnabledPath); symlinkErr != nil {
+			logger.Error("Failed to restore site after maintenance rollback", symlinkErr)
+		}
+	}
+
 	// Test nginx config, if not pass, then restore original configuration
 	res := nginx.Control(nginx.TestConfig)
 	if res.IsError() {
 		// Configuration error, cleanup and revert
-		_ = os.Remove(maintenanceConfigPath)
-		if helper.FileExists(originalEnabledPath + "_backup") {
-			_ = os.Rename(originalEnabledPath+"_backup", originalEnabledPath)
-		}
+		revertMaintenance()
 		return res.GetError()
 	}
 
 	// Reload nginx
 	res = nginx.Control(nginx.Reload)
 	if res.IsError() {
+		revertMaintenance()
+		nginx.Control(nginx.Reload)
 		return res.GetError()
 	}
 
@@ -149,7 +161,7 @@ func DisableMaintenance(name string) (err error) {
 	}
 
 	// Check if the site is in maintenance mode
-	maintenanceConfigPath, err := ResolveEnabledPath(name + MaintenanceSuffix)
+	maintenanceConfigPath, err := resolveEnabledMaintenancePath(name)
 	_, err = os.Stat(maintenanceConfigPath)
 	if err != nil {
 		return
@@ -161,7 +173,7 @@ func DisableMaintenance(name string) (err error) {
 		return err
 	}
 
-	enabledConfigFilePath, err := ResolveEnabledPath(name)
+	enabledConfigFilePath, err := resolveEnabledSymlinkPath(name)
 	if err != nil {
 		return err
 	}
@@ -178,6 +190,13 @@ func DisableMaintenance(name string) (err error) {
 		return
 	}
 
+	// Keep the generated maintenance config so it can be restored on rollback
+	maintenanceContent, err := os.ReadFile(maintenanceConfigPath)
+	if err != nil {
+		_ = os.Remove(enabledConfigFilePath)
+		return
+	}
+
 	// Remove maintenance configuration
 	err = os.Remove(maintenanceConfigPath)
 	if err != nil {
@@ -191,7 +210,7 @@ func DisableMaintenance(name string) (err error) {
 	if res.IsError() {
 		// Configuration error, cleanup and revert
 		_ = os.Remove(enabledConfigFilePath)
-		_ = os.Symlink(configFilePath, maintenanceConfigPath)
+		_ = os.WriteFile(maintenanceConfigPath, maintenanceContent, 0644)
 		return res.GetError()
 	}
 
@@ -209,8 +228,9 @@ func DisableMaintenance(name string) (err error) {
 
 // createMaintenanceConfig creates a maintenance configuration based on the original config.
 // baseDir is the directory used to resolve relative include directives; pass "" to fall back
-// to the nginx configuration directory.
-func createMaintenanceConfig(conf *config.Config, baseDir string) string {
+// to the nginx configuration directory. siteName is forwarded to the maintenance page so it
+// can render a site specific template; pass "" to skip it.
+func createMaintenanceConfig(conf *config.Config, baseDir string, siteName string) string {
 	nginxUIPort := cSettings.ServerSettings.Port
 	schema := "http"
 	if cSettings.ServerSettings.EnableHTTPS {
@@ -268,6 +288,9 @@ func createMaintenanceConfig(conf *config.Config, baseDir string) string {
 		locationContent.WriteString("proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n")
 		locationContent.WriteString("proxy_set_header X-Forwarded-Proto $scheme;\n")
 		locationContent.WriteString("proxy_set_header X-Forwarded-Host $http_host;\n")
+		if siteName != "" {
+			locationContent.WriteString(fmt.Sprintf("proxy_set_header X-Maintenance-Site \"%s\";\n", escapeNginxQuotedValue(siteName)))
+		}
 		locationContent.WriteString("rewrite ^ /pages/maintenance break;\n")
 		locationContent.WriteString(fmt.Sprintf("proxy_pass %s://127.0.0.1:%d;\n", schema, nginxUIPort))
 
@@ -286,6 +309,11 @@ func createMaintenanceConfig(conf *config.Config, baseDir string) string {
 	}
 
 	return content
+}
+
+// escapeNginxQuotedValue escapes a value embedded in a double quoted nginx parameter.
+func escapeNginxQuotedValue(value string) string {
+	return strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(value)
 }
 
 // findServerBlocks finds all server blocks in a configuration

--- a/internal/site/maintenance.go
+++ b/internal/site/maintenance.go
@@ -54,8 +54,10 @@ type maintenanceIncludeExpander struct {
 func EnableMaintenance(name string) (err error) {
 	// Check if the site exists in sites-available
 	configFilePath, err := ResolveAvailablePath(name)
-	_, err = os.Stat(configFilePath)
 	if err != nil {
+		return err
+	}
+	if _, err = os.Stat(configFilePath); err != nil {
 		return
 	}
 
@@ -162,8 +164,10 @@ func DisableMaintenance(name string) (err error) {
 
 	// Check if the site is in maintenance mode
 	maintenanceConfigPath, err := resolveEnabledMaintenancePath(name)
-	_, err = os.Stat(maintenanceConfigPath)
 	if err != nil {
+		return err
+	}
+	if _, err = os.Stat(maintenanceConfigPath); err != nil {
 		return
 	}
 

--- a/internal/site/maintenance_test.go
+++ b/internal/site/maintenance_test.go
@@ -65,6 +65,56 @@ func TestCreateMaintenanceConfig_PreservesForwardedHost(t *testing.T) {
 	}
 }
 
+// TestDisableMaintenanceRestoresMaintenanceConfigWhenReloadFails guards against
+// leaving a site with neither the normal nor the maintenance config enabled:
+// when Nginx accepts the new config on `-t` but fails to reload it, the site
+// must fall back to the maintenance config that was actually still loaded.
+func TestDisableMaintenanceRestoresMaintenanceConfigWhenReloadFails(t *testing.T) {
+	confDir, _ := setupSiteMutationTest(t)
+	availablePath := filepath.Join(confDir, "sites-available", "example.com")
+	if err := os.WriteFile(availablePath, []byte("server {\n    listen 80;\n}\n"), 0o644); err != nil {
+		t.Fatalf("failed to write available config: %v", err)
+	}
+
+	if err := EnableMaintenance("example.com"); err != nil {
+		t.Fatalf("EnableMaintenance() error = %v", err)
+	}
+
+	maintenancePath, err := ResolveEnabledMaintenancePath("example.com")
+	if err != nil {
+		t.Fatalf("ResolveEnabledMaintenancePath() error = %v", err)
+	}
+	maintenanceContentBefore, err := os.ReadFile(maintenancePath)
+	if err != nil {
+		t.Fatalf("failed to read maintenance config: %v", err)
+	}
+
+	enabledPath, err := resolveEnabledSymlinkPath("example.com")
+	if err != nil {
+		t.Fatalf("resolveEnabledSymlinkPath() error = %v", err)
+	}
+
+	reloadMarker := filepath.Join(t.TempDir(), "reload-attempted")
+	settings.NginxSettings.ReloadCmd = fmt.Sprintf(
+		"if [ ! -e %q ]; then touch %q; exit 1; fi", reloadMarker, reloadMarker)
+
+	if err := DisableMaintenance("example.com"); err == nil {
+		t.Fatalf("DisableMaintenance() error = nil, want reload failure")
+	}
+
+	if _, statErr := os.Lstat(enabledPath); !os.IsNotExist(statErr) {
+		t.Fatalf("enabled symlink stat error = %v, want the normal symlink rolled back", statErr)
+	}
+
+	maintenanceContentAfter, readErr := os.ReadFile(maintenancePath)
+	if readErr != nil {
+		t.Fatalf("failed to read maintenance config after rollback: %v", readErr)
+	}
+	if string(maintenanceContentAfter) != string(maintenanceContentBefore) {
+		t.Fatalf("maintenance config after rollback = %q, want %q", maintenanceContentAfter, maintenanceContentBefore)
+	}
+}
+
 func TestCreateMaintenanceConfig_ForwardsSiteName(t *testing.T) {
 	setupMaintenanceTestSettings(t, "")
 

--- a/internal/site/maintenance_test.go
+++ b/internal/site/maintenance_test.go
@@ -50,7 +50,7 @@ func TestCreateMaintenanceConfig_PreservesForwardedHost(t *testing.T) {
 		t.Fatalf("Parse() error = %v", err)
 	}
 
-	content := createMaintenanceConfig(conf, "")
+	content := createMaintenanceConfig(conf, "", "")
 
 	if !strings.Contains(content, "proxy_set_header X-Forwarded-Host $http_host;") {
 		t.Fatalf("maintenance config = %q, want forwarded host header preservation", content)
@@ -62,6 +62,26 @@ func TestCreateMaintenanceConfig_PreservesForwardedHost(t *testing.T) {
 
 	if !strings.Contains(content, "proxy_pass http://127.0.0.1:9000;") {
 		t.Fatalf("maintenance config = %q, want proxy to nginx-ui backend", content)
+	}
+}
+
+func TestCreateMaintenanceConfig_ForwardsSiteName(t *testing.T) {
+	setupMaintenanceTestSettings(t, "")
+
+	p := parser.NewStringParser(`server {
+    listen 80;
+    server_name example.com;
+}`, parser.WithSkipValidDirectivesErr())
+
+	conf, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	content := createMaintenanceConfig(conf, "", `example.com"conf`)
+
+	if !strings.Contains(content, `proxy_set_header X-Maintenance-Site "example.com\"conf";`) {
+		t.Fatalf("maintenance config = %q, want escaped site name header", content)
 	}
 }
 
@@ -101,7 +121,7 @@ location /unexpected {
 		t.Fatalf("Parse() error = %v", err)
 	}
 
-	content := createMaintenanceConfig(conf, sitesAvailableDir)
+	content := createMaintenanceConfig(conf, sitesAvailableDir, "")
 
 	expectedDirectives := []string{
 		"ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem;",
@@ -168,7 +188,7 @@ ssl_session_timeout 10m;
 		t.Fatalf("Parse() error = %v", err)
 	}
 
-	content := createMaintenanceConfig(conf, sitesAvailableDir)
+	content := createMaintenanceConfig(conf, sitesAvailableDir, "")
 
 	for _, expected := range []string{
 		"ssl_session_cache shared:SSL:10m;",
@@ -213,7 +233,7 @@ func TestCreateMaintenanceConfig_ExpandsNestedRelativeWildcardIncludes(t *testin
 		t.Fatalf("Parse() error = %v", err)
 	}
 
-	content := createMaintenanceConfig(conf, sitesAvailableDir)
+	content := createMaintenanceConfig(conf, sitesAvailableDir, "")
 	if !strings.Contains(content, "ssl_protocols TLSv1.2 TLSv1.3;") {
 		t.Fatalf("maintenance config = %q, want TLS directive from nested relative wildcard include", content)
 	}
@@ -255,7 +275,7 @@ ssl_protocols TLSv1.3;
 		t.Fatalf("Parse() error = %v", err)
 	}
 
-	content := createMaintenanceConfig(conf, sitesAvailableDir)
+	content := createMaintenanceConfig(conf, sitesAvailableDir, "")
 	for _, unexpected := range []string{
 		"listen 8443 ssl;",
 		"server_name internal.example.com;",
@@ -292,7 +312,7 @@ func TestCreateMaintenanceConfig_PreservesTLSBlockDirectives(t *testing.T) {
 		t.Fatalf("Parse() error = %v", err)
 	}
 
-	content := createMaintenanceConfig(conf, sitesAvailableDir)
+	content := createMaintenanceConfig(conf, sitesAvailableDir, "")
 	if !strings.Contains(content, "ssl_certificate_by_lua_block") || !strings.Contains(content, "auto_ssl:ssl_certificate()") {
 		t.Fatalf("maintenance config = %q, want TLS block directive preserved", content)
 	}
@@ -324,7 +344,7 @@ func TestCreateMaintenanceConfig_PreservesLuaBlockWithSemicolonsAndBraces(t *tes
 		t.Fatalf("Parse() error = %v", err)
 	}
 
-	content := createMaintenanceConfig(conf, sitesAvailableDir)
+	content := createMaintenanceConfig(conf, sitesAvailableDir, "")
 
 	// Token-level invariants. The gonginx dumper may normalize whitespace inside
 	// the lua block, so assert on tokens that must survive verbatim instead of
@@ -371,7 +391,7 @@ func TestCreateMaintenanceConfig_PreservesQuotedTLSDirectiveParams(t *testing.T)
 		t.Fatalf("Parse() error = %v", err)
 	}
 
-	content := createMaintenanceConfig(conf, sitesAvailableDir)
+	content := createMaintenanceConfig(conf, sitesAvailableDir, "")
 	for _, expected := range []string{
 		`ssl_certificate "/etc/nginx/certs/example cert.pem";`,
 		`ssl_certificate_key "/etc/nginx/certs/example key.pem";`,
@@ -418,7 +438,7 @@ func TestCreateMaintenanceConfig_ExpandsWildcardTLSIncludesInSortedOrder(t *test
 		t.Fatalf("Parse() error = %v", err)
 	}
 
-	content := createMaintenanceConfig(conf, sitesAvailableDir)
+	content := createMaintenanceConfig(conf, sitesAvailableDir, "")
 
 	protocolsIndex := strings.Index(content, "ssl_protocols TLSv1.2 TLSv1.3;")
 	ciphersIndex := strings.Index(content, "ssl_ciphers HIGH:!aNULL:!MD5;")
@@ -459,7 +479,7 @@ func TestCreateMaintenanceConfig_SkipsWildcardIncludesOutsideNginxConfigDir(t *t
 		t.Fatalf("Parse() error = %v", err)
 	}
 
-	content := createMaintenanceConfig(conf, sitesAvailableDir)
+	content := createMaintenanceConfig(conf, sitesAvailableDir, "")
 	if strings.Contains(content, "ssl_ciphers HIGH;") {
 		t.Fatalf("maintenance config = %q, want to skip wildcard outside nginx config dir", content)
 	}
@@ -499,7 +519,7 @@ func TestCreateMaintenanceConfig_LimitsWildcardIncludeMatches(t *testing.T) {
 		t.Fatalf("Parse() error = %v", err)
 	}
 
-	content := createMaintenanceConfig(conf, sitesAvailableDir)
+	content := createMaintenanceConfig(conf, sitesAvailableDir, "")
 	if !strings.Contains(content, "ssl_conf_command Options31 Value31;") {
 		t.Fatalf("maintenance config = %q, want last allowed wildcard match", content)
 	}
@@ -549,7 +569,7 @@ func TestCreateMaintenanceConfig_LimitsWildcardIncludeMatchesAfterFiltering(t *t
 		t.Fatalf("Parse() error = %v", err)
 	}
 
-	content := createMaintenanceConfig(conf, sitesAvailableDir)
+	content := createMaintenanceConfig(conf, sitesAvailableDir, "")
 	if !strings.Contains(content, "ssl_protocols TLSv1.2 TLSv1.3;") {
 		t.Fatalf("maintenance config = %q, want legal wildcard match after filtering invalid matches", content)
 	}
@@ -593,7 +613,7 @@ func TestCreateMaintenanceConfig_RejectsWildcardSymlinkEscape(t *testing.T) {
 		t.Fatalf("Parse() error = %v", err)
 	}
 
-	content := createMaintenanceConfig(conf, sitesAvailableDir)
+	content := createMaintenanceConfig(conf, sitesAvailableDir, "")
 	if strings.Contains(content, "ssl_ciphers EVIL;") {
 		t.Fatalf("maintenance config = %q, want to reject wildcard symlink escape", content)
 	}
@@ -808,7 +828,7 @@ func TestCreateMaintenanceConfig_EnforcesIncludeDepthLimit(t *testing.T) {
 		t.Fatalf("Parse() error = %v", err)
 	}
 
-	content := createMaintenanceConfig(conf, sitesAvailableDir)
+	content := createMaintenanceConfig(conf, sitesAvailableDir, "")
 
 	// Levels 1..maintenanceMaxIncludeDepth must be present.
 	for i := 1; i <= maintenanceMaxIncludeDepth; i++ {
@@ -858,7 +878,7 @@ func TestCreateMaintenanceConfig_AcceptsAbsoluteIncludeInsideConfigDir(t *testin
 		t.Fatalf("Parse() error = %v", err)
 	}
 
-	content := createMaintenanceConfig(conf, sitesAvailableDir)
+	content := createMaintenanceConfig(conf, sitesAvailableDir, "")
 
 	if !strings.Contains(content, "ssl_protocols TLSv1.3;") {
 		t.Fatalf("maintenance config = %q, want directive from absolute include under config dir", content)
@@ -904,7 +924,7 @@ server {
 		t.Fatalf("Parse() error = %v", err)
 	}
 
-	content := createMaintenanceConfig(conf, sitesAvailableDir)
+	content := createMaintenanceConfig(conf, sitesAvailableDir, "")
 
 	// The shared include must appear in both generated server blocks, proving
 	// the visited cache does not leak across server-block expansions.

--- a/internal/site/path.go
+++ b/internal/site/path.go
@@ -21,3 +21,10 @@ func resolveEnabledSymlinkPath(name string) (string, error) {
 
 	return nginx.GetConfSymlinkPath(enabledPath), nil
 }
+
+// resolveEnabledMaintenancePath resolves the generated maintenance config in
+// sites-enabled. It must go through the symlink helper, otherwise Windows setups
+// that include sites-enabled/*.conf would never load the file.
+func resolveEnabledMaintenancePath(name string) (string, error) {
+	return resolveEnabledSymlinkPath(name + MaintenanceSuffix)
+}

--- a/internal/site/path.go
+++ b/internal/site/path.go
@@ -1,9 +1,28 @@
 package site
 
 import (
+	"errors"
+	"strings"
+
 	"github.com/0xJacky/Nginx-UI/internal/config"
 	"github.com/0xJacky/Nginx-UI/internal/nginx"
 )
+
+// ErrInvalidSiteName is returned when a site name cannot be turned into a safe
+// path element (empty, ".", or containing a path separator or "..").
+var ErrInvalidSiteName = errors.New("invalid site name")
+
+// validateSiteName rejects site names that could escape the sites-available /
+// sites-enabled directories once joined into a path. It is intentionally
+// self-contained so every path-building entry point in this package carries its
+// own barrier, regardless of how ResolveAvailablePath/ResolveEnabledPath are
+// implemented.
+func validateSiteName(name string) error {
+	if name == "" || name == "." || strings.ContainsAny(name, `/\`) || strings.Contains(name, "..") {
+		return ErrInvalidSiteName
+	}
+	return nil
+}
 
 func ResolveAvailablePath(name string) (string, error) {
 	return config.ResolveConfPathInDir("sites-available", name)
@@ -22,9 +41,9 @@ func resolveEnabledSymlinkPath(name string) (string, error) {
 	return nginx.GetConfSymlinkPath(enabledPath), nil
 }
 
-// resolveEnabledMaintenancePath resolves the generated maintenance config in
+// ResolveEnabledMaintenancePath resolves the generated maintenance config in
 // sites-enabled. It must go through the symlink helper, otherwise Windows setups
 // that include sites-enabled/*.conf would never load the file.
-func resolveEnabledMaintenancePath(name string) (string, error) {
+func ResolveEnabledMaintenancePath(name string) (string, error) {
 	return resolveEnabledSymlinkPath(name + MaintenanceSuffix)
 }

--- a/internal/site/status.go
+++ b/internal/site/status.go
@@ -29,7 +29,7 @@ func GetSiteStatus(name string) Status {
 		return StatusEnabled
 	}
 
-	mantainanceFilePath, err := ResolveEnabledPath(name + MaintenanceSuffix)
+	mantainanceFilePath, err := resolveEnabledMaintenancePath(name)
 	if err != nil {
 		logger.Error(err)
 		return StatusDisabled

--- a/internal/site/status.go
+++ b/internal/site/status.go
@@ -29,7 +29,7 @@ func GetSiteStatus(name string) Status {
 		return StatusEnabled
 	}
 
-	mantainanceFilePath, err := resolveEnabledMaintenancePath(name)
+	mantainanceFilePath, err := ResolveEnabledMaintenancePath(name)
 	if err != nil {
 		logger.Error(err)
 		return StatusDisabled

--- a/settings/nginx.go
+++ b/settings/nginx.go
@@ -1,19 +1,22 @@
 package settings
 
+const DefaultMaintenanceDir = "/etc/nginx/maintenance"
+
 type Nginx struct {
-	AccessLogPath            string   `json:"access_log_path" protected:"true"`
-	ErrorLogPath             string   `json:"error_log_path" protected:"true"`
-	LogDirWhiteList          []string `json:"log_dir_white_list" protected:"true"`
-	ConfigDir                string   `json:"config_dir" protected:"true"`
-	ConfigPath               string   `json:"config_path" protected:"true"`
-	PIDPath                  string   `json:"pid_path" protected:"true"`
-	SbinPath                 string   `json:"sbin_path" protected:"true"`
-	TestConfigCmd            string   `json:"test_config_cmd" protected:"true"`
-	ReloadCmd                string   `json:"reload_cmd" protected:"true"`
-	RestartCmd               string   `json:"restart_cmd" protected:"true"`
-	StubStatusPort           uint     `json:"stub_status_port" binding:"omitempty,min=1,max=65535"`
-	ContainerName            string   `json:"container_name" protected:"true"`
-	MaintenanceTemplate      string   `json:"maintenance_template"`
+	AccessLogPath       string   `json:"access_log_path" protected:"true"`
+	ErrorLogPath        string   `json:"error_log_path" protected:"true"`
+	LogDirWhiteList     []string `json:"log_dir_white_list" protected:"true"`
+	ConfigDir           string   `json:"config_dir" protected:"true"`
+	ConfigPath          string   `json:"config_path" protected:"true"`
+	PIDPath             string   `json:"pid_path" protected:"true"`
+	SbinPath            string   `json:"sbin_path" protected:"true"`
+	TestConfigCmd       string   `json:"test_config_cmd" protected:"true"`
+	ReloadCmd           string   `json:"reload_cmd" protected:"true"`
+	RestartCmd          string   `json:"restart_cmd" protected:"true"`
+	StubStatusPort      uint     `json:"stub_status_port" binding:"omitempty,min=1,max=65535"`
+	ContainerName       string   `json:"container_name" protected:"true"`
+	MaintenanceDir      string   `json:"maintenance_dir" protected:"true"`
+	MaintenanceTemplate string   `json:"maintenance_template"`
 }
 
 var NginxSettings = &Nginx{}
@@ -23,6 +26,13 @@ func (n *Nginx) GetStubStatusPort() uint {
 		return 51820
 	}
 	return n.StubStatusPort
+}
+
+func (n *Nginx) GetMaintenanceDir() string {
+	if n.MaintenanceDir == "" {
+		return DefaultMaintenanceDir
+	}
+	return n.MaintenanceDir
 }
 
 func (n *Nginx) RunningInAnotherContainer() bool {


### PR DESCRIPTION
## Background

In real-world deployments, a single Nginx instance often hosts multiple business systems (sites). When a specific site needs to go into maintenance temporarily (e.g. for a release or cutover), the previous maintenance mode had the following limitations:

- The maintenance page template directory was hardcoded to `/etc/nginx/maintenance` and could not be customized per deployment.
- All sites shared the same maintenance page, which could not reflect the fact that different business systems have different maintenance windows and need independent notification content.

## Changes

### 1. Configurable maintenance page directory

Added a new `Nginx.MaintenanceDir` setting (environment variable `NGINX_UI_NGINX_MAINTENANCE_DIR`), defaulting to `/etc/nginx/maintenance` for backward compatibility. It can be configured in Settings > Nginx, and also supports mounting a custom directory in Docker.

### 2. Per-site template lookup with graceful fallback

The maintenance template lookup order is now:

1. **`<MaintenanceDir>/<site name>.<filename>`** — a maintenance page dedicated to the site under maintenance;
2. **`<MaintenanceDir>/<filename>`** — the generic maintenance page shared by all sites (the existing `MaintenanceTemplate` setting);
3. **Nginx UI's built-in maintenance page** — used as the final fallback when neither of the above exists or is empty.

For example, with `MaintenanceTemplate=maintenance.html`, a site named `example.com` in maintenance mode will try, in order:

\`\`\`
/etc/nginx/maintenance/example.com.maintenance.html   (site-specific)
/etc/nginx/maintenance/maintenance.html               (generic fallback)
built-in template                                     (final fallback)
\`\`\`

### 3. Implementation

- When generating the maintenance-mode Nginx configuration, an `X-Maintenance-Site` header carrying the site name (properly escaped to prevent config injection) is added to the location block that proxies to Nginx UI.
- The maintenance page handler (`api/pages/maintenance.go`) reads this header, sanitizes both the site name and the configured filename to a single path segment (stripping path separators, rejecting `.`/`..`/NUL bytes) to prevent directory traversal, then loads templates in the priority order above.

### 4. Additional fixes

- Fixed maintenance-mode paths on Windows that were not going through the platform symlink naming rule (`GetConfSymlinkPath`), which caused the generated maintenance config to be skipped when Nginx uses `include sites-enabled/*.conf`.
- Fixed rollback logic in `EnableMaintenance`/`DisableMaintenance` when `nginx -t` or `reload` fails (previously it tried to restore a `_backup` file that was never created, or overwrote the maintenance config with a symlink), preventing a site from being left permanently unusable after a failed maintenance switch.

## Impact

- Users who have not set `MaintenanceTemplate` are unaffected and still fall back to the built-in maintenance page.
- Users who have set `MaintenanceTemplate` but not `MaintenanceDir` are unaffected (the default directory is unchanged).
- Sites already in maintenance mode need to be toggled off and back on once so the regenerated Nginx config includes the `X-Maintenance-Site` header and picks up per-site matching.

## Testing

- Added/updated unit tests covering:
  - Site-specific template priority, fallback to the generic template, fallback when the generic template is empty, path-traversal sanitization, and default directory fallback;
  - Injection and escaping of the site name header when generating the maintenance config;
  - Rollback behavior when enabling/disabling maintenance mode fails.
- `GOWORK=off go test -tags=unembed -race -cover -count=1 ./...` (affected packages)
- `bun run lint` / `bun run typecheck`

## Documentation

Updated English, Simplified Chinese, and Traditional Chinese configuration docs (`config-nginx.md`, `env.md`) and the `app.example.ini` example configuration accordingly.