### PR TITLE
fix(upstream): deduplicate symlinked config targets

### DIFF
--- a/internal/cache/index.go
+++ b/internal/cache/index.go
@@ -845,6 +845,27 @@ func (s *Scanner) scanSingleFileInternal(filePath string, skipPostScan bool) err
 			return nil
 		}
 
+		// Give every consumer the target's identity before reading its content.
+		resolvedPath, err := nginx.EvalSymlinks(filePath)
+		if err != nil {
+			logger.Debugf("Skipping unresolved symlink: %s (%v)", filePath, err)
+			return nil
+		}
+
+		// Keep the configured root prefix so symlink scans and file events use
+		// the same key even when an ancestor of the config directory is a symlink.
+		root := nginx.GetConfPath()
+		resolvedRoot, err := nginx.EvalSymlinks(root)
+		if err != nil {
+			logger.Debugf("Skipping symlink with unresolved config root: %s (%v)", filePath, err)
+			return nil
+		}
+		if relativePath, err := filepath.Rel(resolvedRoot, resolvedPath); err == nil &&
+			relativePath != ".." && !strings.HasPrefix(relativePath, ".."+string(filepath.Separator)) {
+			resolvedPath = filepath.Join(root, relativePath)
+		}
+		filePath = resolvedPath
+
 		// Process symlinks to files, but use the target's info for size check
 		fileInfo = targetInfo
 	}

--- a/internal/cache/index_test.go
+++ b/internal/cache/index_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/0xJacky/Nginx-UI/settings"
+	"github.com/fsnotify/fsnotify"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -68,7 +69,9 @@ func TestPeriodicScanIntervalUsesRemoteIntervalWhenPolling(t *testing.T) {
 }
 
 func TestScanDirectoryRecursiveReadsConfigsThroughTargetFilesystem(t *testing.T) {
-	confDir := t.TempDir()
+	realConfDir := t.TempDir()
+	confDir := filepath.Join(t.TempDir(), "nginx")
+	require.NoError(t, os.Symlink(realConfDir, confDir))
 	originalConfigDir := settings.NginxSettings.ConfigDir
 	settings.NginxSettings.ConfigDir = confDir
 	t.Cleanup(func() { settings.NginxSettings.ConfigDir = originalConfigDir })
@@ -85,6 +88,12 @@ func TestScanDirectoryRecursiveReadsConfigsThroughTargetFilesystem(t *testing.T)
 
 	siteConf := filepath.Join(sitesDir, "example.conf")
 	require.NoError(t, os.WriteFile(siteConf, []byte("server { listen 80; }"), 0o644))
+	enabledDir := filepath.Join(confDir, "sites-enabled")
+	require.NoError(t, os.MkdirAll(enabledDir, 0o755))
+	enabledConf := filepath.Join(enabledDir, "example.conf")
+	require.NoError(t, os.Symlink(filepath.Join("..", "sites-available", "example.conf"), enabledConf))
+	require.NoError(t, os.Symlink(filepath.Join(realConfDir, "sites-available", "example.conf"), filepath.Join(enabledDir, "absolute.conf")))
+	require.NoError(t, os.Symlink("missing.conf", filepath.Join(enabledDir, "broken.conf")))
 	mainConf := filepath.Join(confDir, "nginx.conf")
 	require.NoError(t, os.WriteFile(mainConf, []byte("events {}"), 0o644))
 	// Certificates live under ssl/ which the scanner must skip.
@@ -110,13 +119,14 @@ func TestScanDirectoryRecursiveReadsConfigsThroughTargetFilesystem(t *testing.T)
 		seen[configPath] = string(content)
 		return nil
 	})
+	indexer := newTestSearchIndexer(t, 1024)
+	RegisterCallback("search_test", indexer.handleConfigScan)
 
 	s := &Scanner{debouncer: newFileEventDebouncer()}
 	fileCount, dirCount := 0, 0
 	require.NoError(t, s.scanDirectoryRecursive(context.Background(), confDir, &fileCount, &dirCount))
 
 	mu.Lock()
-	defer mu.Unlock()
 	paths := make([]string, 0, len(seen))
 	for p := range seen {
 		paths = append(paths, p)
@@ -125,4 +135,29 @@ func TestScanDirectoryRecursiveReadsConfigsThroughTargetFilesystem(t *testing.T)
 	assert.Equal(t, []string{mainConf, siteConf}, paths)
 	assert.Equal(t, "server { listen 80; }", seen[siteConf])
 	assert.Equal(t, "events {}", seen[mainConf])
+	mu.Unlock()
+
+	// A save only rescans the available path; no alias may retain old content.
+	require.NoError(t, os.WriteFile(siteConf, []byte("server { listen 9090; }"), 0o644))
+	require.NoError(t, s.scanSingleFileInternal(siteConf, true))
+	results, err := indexer.Search(context.Background(), "80", 10)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+	results, err = indexer.Search(context.Background(), "9090", 10)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, siteConf, results[0].Document.Path)
+
+	// Removing the enabled link must leave the available config indexed.
+	require.NoError(t, os.Remove(enabledConf))
+	s.handleFileEvent(fsnotify.Event{Name: enabledConf, Op: fsnotify.Remove})
+	results, err = indexer.Search(context.Background(), "9090", 10)
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+
+	require.NoError(t, os.Remove(siteConf))
+	s.handleFileEvent(fsnotify.Event{Name: siteConf, Op: fsnotify.Remove})
+	results, err = indexer.Search(context.Background(), "9090", 10)
+	require.NoError(t, err)
+	assert.Empty(t, results)
 }

--- a/internal/upstream/service.go
+++ b/internal/upstream/service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/0xJacky/Nginx-UI/internal/cache"
+	"github.com/0xJacky/Nginx-UI/internal/nginx"
 	"github.com/0xJacky/Nginx-UI/model"
 	"github.com/0xJacky/Nginx-UI/settings"
 	"github.com/uozi-tech/cosy/logger"
@@ -34,10 +35,12 @@ type Service struct {
 	availabilityMap map[string]*Status     // key: host:port
 	configTargets   map[string][]string    // configPath -> []targetKeys
 	configUpstreams map[string][]string    // configPath -> []upstreamNames
+	configAliases   map[string]string      // scanned configPath -> canonical configPath
 	// Public upstream definitions storage
 	Upstreams                 map[string]*Definition // key: upstream name
 	upstreamsMutex            sync.RWMutex
 	targetsMutex              sync.RWMutex
+	configScanMutex           sync.Mutex
 	lastUpdateTime            time.Time
 	testInProgress            bool
 	testMutex                 sync.Mutex
@@ -75,6 +78,7 @@ func GetUpstreamService() *Service {
 			availabilityMap:           make(map[string]*Status),
 			configTargets:             make(map[string][]string),
 			configUpstreams:           make(map[string][]string),
+			configAliases:             make(map[string]string),
 			Upstreams:                 make(map[string]*Definition),
 			lastUpdateTime:            time.Now(),
 			disabledSocketsCacheValid: false, // Initialize as invalid to force first load
@@ -90,23 +94,79 @@ func init() {
 
 // scanForProxyTargets is the callback function for cache scanner
 func scanForProxyTargets(configPath string, content []byte) error {
+	service := GetUpstreamService()
+	canonicalPath := configPath
+	if len(content) > 0 {
+		if resolvedPath, err := nginx.EvalSymlinks(configPath); err == nil {
+			canonicalPath = resolvedPath
+		}
+	}
+
+	service.configScanMutex.Lock()
+	defer service.configScanMutex.Unlock()
+
 	// Handle file removal - clean up targets from this config
 	if len(content) == 0 {
-		service := GetUpstreamService()
-		service.RemoveConfigTargets(configPath)
+		canonicalPath, isLastAlias := service.removeConfigAlias(configPath)
+		if isLastAlias {
+			service.RemoveConfigTargets(canonicalPath)
+		}
 		return nil
 	}
+
+	obsoletePath := service.trackConfigAlias(configPath, canonicalPath)
+	if obsoletePath != "" {
+		service.RemoveConfigTargets(obsoletePath)
+	}
+	configPath = canonicalPath
 
 	// logger.Debug("scanForProxyTargets", configPath)
 	// Parse proxy targets and upstream definitions from config content
 	result := ParseProxyTargetsAndUpstreamsFromRawContent(string(content))
 
-	service := GetUpstreamService()
 	service.updateUpstreamsFromConfig(configPath, result.Upstreams)
 	service.updateTargetsFromConfig(configPath, service.filterKnownUpstreamReferences(result.ProxyTargets))
 	service.removeKnownUpstreamReferenceTargets()
 
 	return nil
+}
+
+// trackConfigAlias gives symlinked and real paths a shared identity while
+// retaining each observed path so removals can release the identity safely.
+func (s *Service) trackConfigAlias(configPath, canonicalPath string) (obsoletePath string) {
+	if s.configAliases == nil {
+		s.configAliases = make(map[string]string)
+	}
+
+	previousPath := s.configAliases[configPath]
+	s.configAliases[configPath] = canonicalPath
+	if previousPath == "" || previousPath == canonicalPath {
+		return ""
+	}
+
+	for alias, trackedPath := range s.configAliases {
+		if alias != configPath && trackedPath == previousPath {
+			return ""
+		}
+	}
+
+	return previousPath
+}
+
+func (s *Service) removeConfigAlias(configPath string) (canonicalPath string, isLastAlias bool) {
+	canonicalPath, tracked := s.configAliases[configPath]
+	if !tracked {
+		return configPath, true
+	}
+
+	delete(s.configAliases, configPath)
+	for _, trackedPath := range s.configAliases {
+		if trackedPath == canonicalPath {
+			return canonicalPath, false
+		}
+	}
+
+	return canonicalPath, true
 }
 
 // updateTargetsFromConfig updates proxy targets from a specific config file
@@ -379,6 +439,9 @@ func (s *Service) InvalidateDisabledSocketsCache() {
 
 // ClearTargets clears all targets (useful for testing or reloading)
 func (s *Service) ClearTargets() {
+	s.configScanMutex.Lock()
+	defer s.configScanMutex.Unlock()
+
 	s.targetsMutex.Lock()
 	s.targets = make(map[string]*TargetInfo)
 	s.availabilityMap = make(map[string]*Status)
@@ -390,6 +453,8 @@ func (s *Service) ClearTargets() {
 	s.configUpstreams = make(map[string][]string)
 	s.Upstreams = make(map[string]*Definition)
 	s.upstreamsMutex.Unlock()
+
+	s.configAliases = make(map[string]string)
 
 	// logger.Debug("Cleared all proxy targets and upstream definitions")
 }

--- a/internal/upstream/service.go
+++ b/internal/upstream/service.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/0xJacky/Nginx-UI/internal/cache"
-	"github.com/0xJacky/Nginx-UI/internal/nginx"
 	"github.com/0xJacky/Nginx-UI/model"
 	"github.com/0xJacky/Nginx-UI/settings"
 	"github.com/uozi-tech/cosy/logger"
@@ -35,12 +34,10 @@ type Service struct {
 	availabilityMap map[string]*Status     // key: host:port
 	configTargets   map[string][]string    // configPath -> []targetKeys
 	configUpstreams map[string][]string    // configPath -> []upstreamNames
-	configAliases   map[string]string      // scanned configPath -> canonical configPath
 	// Public upstream definitions storage
 	Upstreams                 map[string]*Definition // key: upstream name
 	upstreamsMutex            sync.RWMutex
 	targetsMutex              sync.RWMutex
-	configScanMutex           sync.Mutex
 	lastUpdateTime            time.Time
 	testInProgress            bool
 	testMutex                 sync.Mutex
@@ -78,7 +75,6 @@ func GetUpstreamService() *Service {
 			availabilityMap:           make(map[string]*Status),
 			configTargets:             make(map[string][]string),
 			configUpstreams:           make(map[string][]string),
-			configAliases:             make(map[string]string),
 			Upstreams:                 make(map[string]*Definition),
 			lastUpdateTime:            time.Now(),
 			disabledSocketsCacheValid: false, // Initialize as invalid to force first load
@@ -94,79 +90,23 @@ func init() {
 
 // scanForProxyTargets is the callback function for cache scanner
 func scanForProxyTargets(configPath string, content []byte) error {
-	service := GetUpstreamService()
-	canonicalPath := configPath
-	if len(content) > 0 {
-		if resolvedPath, err := nginx.EvalSymlinks(configPath); err == nil {
-			canonicalPath = resolvedPath
-		}
-	}
-
-	service.configScanMutex.Lock()
-	defer service.configScanMutex.Unlock()
-
 	// Handle file removal - clean up targets from this config
 	if len(content) == 0 {
-		canonicalPath, isLastAlias := service.removeConfigAlias(configPath)
-		if isLastAlias {
-			service.RemoveConfigTargets(canonicalPath)
-		}
+		service := GetUpstreamService()
+		service.RemoveConfigTargets(configPath)
 		return nil
 	}
-
-	obsoletePath := service.trackConfigAlias(configPath, canonicalPath)
-	if obsoletePath != "" {
-		service.RemoveConfigTargets(obsoletePath)
-	}
-	configPath = canonicalPath
 
 	// logger.Debug("scanForProxyTargets", configPath)
 	// Parse proxy targets and upstream definitions from config content
 	result := ParseProxyTargetsAndUpstreamsFromRawContent(string(content))
 
+	service := GetUpstreamService()
 	service.updateUpstreamsFromConfig(configPath, result.Upstreams)
 	service.updateTargetsFromConfig(configPath, service.filterKnownUpstreamReferences(result.ProxyTargets))
 	service.removeKnownUpstreamReferenceTargets()
 
 	return nil
-}
-
-// trackConfigAlias gives symlinked and real paths a shared identity while
-// retaining each observed path so removals can release the identity safely.
-func (s *Service) trackConfigAlias(configPath, canonicalPath string) (obsoletePath string) {
-	if s.configAliases == nil {
-		s.configAliases = make(map[string]string)
-	}
-
-	previousPath := s.configAliases[configPath]
-	s.configAliases[configPath] = canonicalPath
-	if previousPath == "" || previousPath == canonicalPath {
-		return ""
-	}
-
-	for alias, trackedPath := range s.configAliases {
-		if alias != configPath && trackedPath == previousPath {
-			return ""
-		}
-	}
-
-	return previousPath
-}
-
-func (s *Service) removeConfigAlias(configPath string) (canonicalPath string, isLastAlias bool) {
-	canonicalPath, tracked := s.configAliases[configPath]
-	if !tracked {
-		return configPath, true
-	}
-
-	delete(s.configAliases, configPath)
-	for _, trackedPath := range s.configAliases {
-		if trackedPath == canonicalPath {
-			return canonicalPath, false
-		}
-	}
-
-	return canonicalPath, true
 }
 
 // updateTargetsFromConfig updates proxy targets from a specific config file
@@ -439,9 +379,6 @@ func (s *Service) InvalidateDisabledSocketsCache() {
 
 // ClearTargets clears all targets (useful for testing or reloading)
 func (s *Service) ClearTargets() {
-	s.configScanMutex.Lock()
-	defer s.configScanMutex.Unlock()
-
 	s.targetsMutex.Lock()
 	s.targets = make(map[string]*TargetInfo)
 	s.availabilityMap = make(map[string]*Status)
@@ -453,8 +390,6 @@ func (s *Service) ClearTargets() {
 	s.configUpstreams = make(map[string][]string)
 	s.Upstreams = make(map[string]*Definition)
 	s.upstreamsMutex.Unlock()
-
-	s.configAliases = make(map[string]string)
 
 	// logger.Debug("Cleared all proxy targets and upstream definitions")
 }

--- a/internal/upstream/service_test.go
+++ b/internal/upstream/service_test.go
@@ -1,6 +1,10 @@
 package upstream
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestScanForProxyTargets_IgnoresCrossFileUpstreamReferences(t *testing.T) {
 	service := GetUpstreamService()
@@ -78,5 +82,85 @@ upstream new_backend {
 
 	if !service.IsUpstreamName("new_backend") {
 		t.Fatalf("expected new_backend to be registered after config update")
+	}
+}
+
+func TestScanForProxyTargets_ReplacesStaleTargetFromSymlinkedConfig(t *testing.T) {
+	service := GetUpstreamService()
+	service.ClearTargets()
+
+	t.Cleanup(func() {
+		service.ClearTargets()
+	})
+
+	root := t.TempDir()
+	availableDir := filepath.Join(root, "sites-available")
+	enabledDir := filepath.Join(root, "sites-enabled")
+	if err := os.Mkdir(availableDir, 0o755); err != nil {
+		t.Fatalf("create sites-available directory: %v", err)
+	}
+	if err := os.Mkdir(enabledDir, 0o755); err != nil {
+		t.Fatalf("create sites-enabled directory: %v", err)
+	}
+
+	availablePath := filepath.Join(availableDir, "example")
+	enabledPath := filepath.Join(enabledDir, "example")
+	if err := os.WriteFile(availablePath, []byte("initial"), 0o644); err != nil {
+		t.Fatalf("create available config: %v", err)
+	}
+	if err := os.Symlink(availablePath, enabledPath); err != nil {
+		t.Fatalf("enable config: %v", err)
+	}
+
+	initialConfig := `
+server {
+    location / {
+        proxy_pass http://192.168.10.100:8080;
+    }
+}`
+
+	updatedConfig := `
+server {
+    location / {
+        proxy_pass http://192.168.10.101:8080;
+    }
+}`
+
+	if err := scanForProxyTargets(availablePath, []byte(initialConfig)); err != nil {
+		t.Fatalf("scan available config: %v", err)
+	}
+	if err := scanForProxyTargets(enabledPath, []byte(initialConfig)); err != nil {
+		t.Fatalf("scan enabled config: %v", err)
+	}
+	if err := scanForProxyTargets(availablePath, []byte(updatedConfig)); err != nil {
+		t.Fatalf("scan updated config: %v", err)
+	}
+
+	targets := service.GetTargets()
+	if len(targets) != 1 {
+		t.Fatalf("expected only the updated target, got %d: %+v", len(targets), targets)
+	}
+	if targets[0].Host != "192.168.10.101" || targets[0].Port != "8080" {
+		t.Fatalf("unexpected target after config update: %+v", targets[0])
+	}
+
+	if err := os.Remove(enabledPath); err != nil {
+		t.Fatalf("disable config: %v", err)
+	}
+	if err := scanForProxyTargets(enabledPath, nil); err != nil {
+		t.Fatalf("remove enabled config: %v", err)
+	}
+	if targets := service.GetTargets(); len(targets) != 1 {
+		t.Fatalf("expected available config target to remain, got %d: %+v", len(targets), targets)
+	}
+
+	if err := os.Remove(availablePath); err != nil {
+		t.Fatalf("remove available config: %v", err)
+	}
+	if err := scanForProxyTargets(availablePath, nil); err != nil {
+		t.Fatalf("remove available config from scan: %v", err)
+	}
+	if targets := service.GetTargets(); len(targets) != 0 {
+		t.Fatalf("expected target removal with the last config path, got %d: %+v", len(targets), targets)
 	}
 }

--- a/internal/upstream/service_test.go
+++ b/internal/upstream/service_test.go
@@ -4,6 +4,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/0xJacky/Nginx-UI/internal/cache"
+	"github.com/0xJacky/Nginx-UI/settings"
 )
 
 func TestScanForProxyTargets_IgnoresCrossFileUpstreamReferences(t *testing.T) {
@@ -94,6 +97,12 @@ func TestScanForProxyTargets_ReplacesStaleTargetFromSymlinkedConfig(t *testing.T
 	})
 
 	root := t.TempDir()
+	originalSettings := *settings.NginxSettings
+	settings.NginxSettings.ConfigDir = root
+	settings.NginxSettings.HostMode = ""
+	settings.NginxSettings.HostAccessMode = ""
+	t.Cleanup(func() { *settings.NginxSettings = originalSettings })
+
 	availableDir := filepath.Join(root, "sites-available")
 	enabledDir := filepath.Join(root, "sites-enabled")
 	if err := os.Mkdir(availableDir, 0o755); err != nil {
@@ -126,11 +135,11 @@ server {
     }
 }`
 
-	if err := scanForProxyTargets(availablePath, []byte(initialConfig)); err != nil {
-		t.Fatalf("scan available config: %v", err)
+	if err := os.WriteFile(availablePath, []byte(initialConfig), 0o644); err != nil {
+		t.Fatalf("write initial config: %v", err)
 	}
-	if err := scanForProxyTargets(enabledPath, []byte(initialConfig)); err != nil {
-		t.Fatalf("scan enabled config: %v", err)
+	if err := cache.GetScanner().ScanAllConfigs(); err != nil {
+		t.Fatalf("scan available and enabled configs: %v", err)
 	}
 	if err := scanForProxyTargets(availablePath, []byte(updatedConfig)); err != nil {
 		t.Fatalf("scan updated config: %v", err)
@@ -142,6 +151,9 @@ server {
 	}
 	if targets[0].Host != "192.168.10.101" || targets[0].Port != "8080" {
 		t.Fatalf("unexpected target after config update: %+v", targets[0])
+	}
+	if configPath := service.GetTargetInfos()[0].ConfigPath; configPath != availablePath {
+		t.Fatalf("unexpected config path: got %q, want %q", configPath, availablePath)
 	}
 
 	if err := os.Remove(enabledPath); err != nil {


### PR DESCRIPTION
## Summary

Fixes #1841.

An enabled site was scanned under both its `sites-available` path and its `sites-enabled` symlink. Saving the available file updated only one identity, leaving obsolete upstream targets, search content, and log registrations behind.

- Normalize file symlinks in the shared cache scanner before reading content and invoking callbacks, so every consumer receives the same target path.
- Resolve only files identified as symlinks by `Lstat`; regular files incur no extra path-resolution calls. Skip failed resolutions with a debug log and leave existing consumer state intact.
- Remove the upstream-specific alias map and scan mutex. The upstream callback no longer performs filesystem I/O.
- Extend the scanner and upstream regressions to cover updates, removals, relative and absolute symlinks, broken links, and a symlinked config root.

## API compatibility

For an enabled site, upstream `config_path` now consistently identifies the `sites-available` target instead of varying with scan order. Targets within the configuration tree retain the configured root prefix, including when that root has symlinked ancestors. Symlink targets outside that tree use their resolved path.

## Verification

- The scanner regression fails with the original scanner and passes with this change.
- `GOWORK=off go test -tags=unembed -race -cover -count=1 ./...`
- `gofmt` and `git diff --check`
