### PR TITLE
fix(nodeauth): authenticate paired nodes behind path prefixes

### DIFF
--- a/docs/guide/nginx-proxy-example.md
+++ b/docs/guide/nginx-proxy-example.md
@@ -68,3 +68,16 @@ Within the second server block, the location `/` section contains proxy settings
 `9000`. The proxy settings also include a number of headers for proper handling of the forwarded requests, such
 as `Host`,
 `X-Real-IP`, `X-Forwarded-For`, `X-Forwarded-Proto`, `X-Forwarded-Host`, `Upgrade`, and `Connection`.
+
+## Paired nodes behind a path prefix
+
+If a node is published under `/nui/`, configure its URL on the controller as
+`https://node.example.com/nui`. Use `location /nui/` with a trailing-slash
+`proxy_pass http://127.0.0.1:9000/` so the backend receives `/api/...` rather
+than `/nui/api/...`.
+
+Paired HTTP requests and WebSocket handshakes sign the backend path after
+removing the configured node URL prefix. The outgoing URL still includes that
+prefix. The remaining path, query, method, and body remain authenticated;
+forwarded headers do not determine the signed path. Additional proxy rewrites
+of the remaining path or query will invalidate the signature.

--- a/internal/nodeauth/transport.go
+++ b/internal/nodeauth/transport.go
@@ -195,6 +195,16 @@ func applyPairedAuthentication(request *http.Request, database *gorm.DB, node *m
 	if err != nil {
 		return err
 	}
+	// The configured node URL prefix is removed by the reverse proxy before
+	// verification. Sign the backend path, while retaining the original URL
+	// for the actual HTTP request (and WebSocket handshake).
+	wireURL := request.URL
+	signingURL, err := nodeSigningURL(wireURL, node.URL)
+	if err != nil {
+		return err
+	}
+	request.URL = signingURL
+	defer func() { request.URL = wireURL }()
 	return SignRequestWithKey(
 		request,
 		credential.CredentialID,
@@ -202,4 +212,30 @@ func applyPairedAuthentication(request *http.Request, database *gorm.DB, node *m
 		ed25519.PrivateKey(privateKey),
 		now,
 	)
+}
+
+// nodeSigningURL removes only the configured path prefix, on a segment boundary.
+// Never derive the signed path from forwarded headers supplied by a peer.
+func nodeSigningURL(wireURL *url.URL, nodeURL string) (*url.URL, error) {
+	baseURL, err := url.Parse(nodeURL)
+	if err != nil {
+		return nil, err
+	}
+	prefix := strings.TrimRight(baseURL.EscapedPath(), "/")
+	if prefix == "" {
+		return wireURL, nil
+	}
+	path := wireURL.EscapedPath()
+	if !strings.HasPrefix(path, prefix+"/") {
+		return nil, errors.New("node request path is outside the configured URL prefix")
+	}
+	path = strings.TrimPrefix(path, prefix)
+	decodedPath, err := url.PathUnescape(path)
+	if err != nil {
+		return nil, err
+	}
+	signingURL := *wireURL
+	signingURL.Path = decodedPath
+	signingURL.RawPath = path
+	return &signingURL, nil
 }

--- a/internal/nodeauth/transport_subpath_test.go
+++ b/internal/nodeauth/transport_subpath_test.go
@@ -1,0 +1,113 @@
+package nodeauth
+
+import (
+	"crypto/ed25519"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xJacky/Nginx-UI/model"
+	"github.com/0xJacky/Nginx-UI/settings"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPairedAuthenticationBehindPathPrefix(t *testing.T) {
+	for i, prefix := range []string{"", "/", "/nui", "/nested/nui/"} {
+		t.Run(fmt.Sprintf("prefix_%d", i), func(t *testing.T) {
+			database, privateKey, _ := setupSignatureTest(t)
+			require.NoError(t, database.AutoMigrate(&model.Node{}, &model.NodeCredential{}))
+			credentialID := "22222222-2222-4222-8222-222222222222"
+			encrypted, err := EncryptPrivateCredential(SigningCredentialPurpose(credentialID), privateKey)
+			require.NoError(t, err)
+			node := &model.Node{AuthMethod: model.NodeAuthMethodPaired, Enabled: true}
+			require.NoError(t, database.Create(node).Error)
+			require.NoError(t, database.Create(&model.NodeCredential{
+				PublicKey: privateKey.Public().(ed25519.PublicKey), NodeID: node.ID, CredentialID: credentialID, TargetInstanceID: settings.NodeSettings.InstanceID,
+				EncryptedPrivateKey: encrypted, Status: model.NodeCredentialStatusActive,
+			}).Error)
+			replay := NewReplayCache(100)
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer CloseStagedBody(r)
+				if _, err := verifyRequest(r, database, time.Now(), replay); err != nil {
+					http.Error(w, err.Error(), http.StatusForbidden)
+					return
+				}
+				w.WriteHeader(http.StatusNoContent)
+			})
+			// StripPrefix models the proxy_pass trailing-slash path rewrite.
+			decodedPrefix := strings.TrimRight(prefix, "/")
+			server := httptest.NewServer(http.StripPrefix(decodedPrefix, handler))
+			defer server.Close()
+			node.URL = server.URL + prefix
+			require.NoError(t, database.Save(node).Error)
+			for _, socket := range []bool{false, true} {
+				for _, suffix := range []string{"/api/node", "/api/sites/a%2Fb?reload=true&source=cluster"} {
+					wireURL := server.URL + strings.TrimRight(prefix, "/") + suffix
+					request, err := http.NewRequest(http.MethodGet, wireURL, nil)
+					require.NoError(t, err)
+					client := &http.Client{Transport: http.DefaultTransport}
+					if socket {
+						require.NoError(t, SignWebSocketHeaders(node, strings.Replace(wireURL, "http://", "ws://", 1), request.Header))
+					} else {
+						client.Transport = NewTransport(node, http.DefaultTransport)
+					}
+					response, err := client.Do(request)
+					require.NoError(t, err)
+					body, err := io.ReadAll(response.Body)
+					require.NoError(t, err)
+					require.NoError(t, response.Body.Close())
+					require.Equal(t, http.StatusNoContent, response.StatusCode, "socket=%v: %s", socket, body)
+					require.Equal(t, wireURL, request.URL.String(), "signing must preserve the wire URL")
+				}
+			}
+			for _, tamper := range []string{"path", "query"} {
+				request, err := http.NewRequest(http.MethodGet, server.URL+strings.TrimRight(prefix, "/")+"/api/node?reload=true", nil)
+				require.NoError(t, err)
+				require.NoError(t, SignWebSocketHeaders(node, request.URL.String(), request.Header))
+				if tamper == "path" {
+					request.URL.Path += "/changed"
+					request.URL.RawPath = ""
+				} else {
+					request.URL.RawQuery = "reload=false"
+				}
+				response, err := server.Client().Do(request)
+				require.NoError(t, err)
+				require.NoError(t, response.Body.Close())
+				require.Equal(t, http.StatusForbidden, response.StatusCode)
+			}
+		})
+	}
+}
+
+func TestNodeSigningURLPreservesPathBinding(t *testing.T) {
+	for _, test := range []struct {
+		name, base, wire, want string
+		invalid                bool
+	}{
+		{"no prefix", "https://node", "https://node/api/node?q=a%2Fb", "/api/node", false},
+		{"nested prefix", "https://node/nui/child/", "https://node/nui/child/api/nui", "/api/nui", false},
+		{"encoded path", "https://node/n%75i", "https://node/n%75i/api/a%2Fb", "/api/a%2Fb", false},
+		{"segment boundary", "https://node/nui", "https://node/nuix/api/node", "", true},
+		{"missing prefix", "https://node/nui", "https://node/api/node", "", true},
+		{"invalid base", "://bad", "https://node/api/node", "", true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			wire, err := url.Parse(test.wire)
+			require.NoError(t, err)
+			signed, err := nodeSigningURL(wire, test.base)
+			if test.invalid {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.want, signed.EscapedPath())
+			require.Equal(t, wire.RawQuery, signed.RawQuery)
+			require.Equal(t, test.wire, wire.String())
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1849.

A controller configured with `https://node.example.com/nui` signs `/nui/api/node`, but a prefix-stripping reverse proxy delivers `/api/node` to the verifier. This produces a 403 even with a valid paired credential.

Sign the backend path after removing the configured node URL prefix on a segment boundary, then restore the outgoing URL. The shared paired-authentication boundary covers HTTP requests and WebSocket handshake headers. Verification remains unchanged: the remaining escaped path, query, method, body, target instance, and replay protections still apply. Forwarded headers are not trusted to choose a signing path. The reverse-proxy guide documents the required prefix rewrite.

Validation:
- Regression fails against unchanged `dev` for `/nui` and a nested prefix, with `node request signature is invalid`.
- Real local HTTP server using `http.StripPrefix`, paired credentials, and the existing verifier covers HTTP transport and WebSocket header signing, root/nested/trailing-slash prefixes, preserved outgoing URLs, escaped paths, and rejected path/query tampering.
- `GOWORK=off go test -tags=unembed -race -count=1 ./internal/nodeauth` passes.
- Full required `GOWORK=off go test -tags=unembed -race -cover -count=1 ./...` passes on Go 1.27.1, macOS arm64.

The proxy fixture exercises the authentication boundary; it does not launch Nginx or perform a WebSocket protocol upgrade. Additional rewrites of the remaining path/query are outside this fix.
