### PR TITLE
feat(auth): make secure session timeout configurable

### DIFF
--- a/app.example.ini
+++ b/app.example.ini
@@ -18,6 +18,7 @@ IPWhiteList         =
 TrustedProxies      =
 BanThresholdMinutes = 10
 MaxAttempts         = 10
+SecureSessionTimeoutMinutes = 10
 
 [casdoor]
 Endpoint        =

--- a/docs/guide/config-auth.md
+++ b/docs/guide/config-auth.md
@@ -46,3 +46,12 @@ By default, if a user fails to log in 10 times within 10 minutes, the user will 
 - Default: `10`
 
 By default, a user can try to log in 10 times within 10 minutes.
+
+## SecureSessionTimeoutMinutes
+- Type: `int`
+- Default: `10`
+
+Controls how many minutes a successful TOTP or passkey verification authorizes
+protected operations. The setting does not change the normal login session
+lifetime. Values must be positive; missing, zero, and negative values use the
+10-minute default.

--- a/docs/guide/env.md
+++ b/docs/guide/env.md
@@ -31,6 +31,7 @@ Applicable for version v2.0.0-beta.37 and above.
 | TrustedProxies        | NGINX_UI_AUTH_TRUSTED_PROXIES      |
 | BanThresholdMinutes   | NGINX_UI_AUTH_BAN_THRESHOLD_MINUTES |
 | MaxAttempts           | NGINX_UI_AUTH_MAX_ATTEMPTS          |
+| SecureSessionTimeoutMinutes | NGINX_UI_AUTH_SECURE_SESSION_TIMEOUT_MINUTES |
 
 ## Casdoor
 | Configuration Setting | Environment Variable              |

--- a/internal/user/otp.go
+++ b/internal/user/otp.go
@@ -12,6 +12,7 @@ import (
 	"github.com/0xJacky/Nginx-UI/internal/notification"
 	"github.com/0xJacky/Nginx-UI/model"
 	"github.com/0xJacky/Nginx-UI/query"
+	"github.com/0xJacky/Nginx-UI/settings"
 	"github.com/google/uuid"
 	"github.com/pquerna/otp/totp"
 	"gorm.io/gorm"
@@ -110,9 +111,19 @@ func secureSessionIDCacheKey(sessionId string) string {
 	return fmt.Sprintf("2fa_secure_session:_%s", sessionId)
 }
 
-// DefaultSecureSessionDuration is the two factor session window used by every
-// release build. See secure_session.go and secure_session_dev.go.
-const DefaultSecureSessionDuration = 10 * time.Minute
+// DefaultSecureSessionDuration is the fallback two factor session window when
+// no valid timeout is configured. See secure_session.go and secure_session_dev.go.
+const DefaultSecureSessionDuration = time.Duration(settings.DefaultSecureSessionTimeoutMinutes) * time.Minute
+
+const maxSecureSessionTimeoutMinutes = int((1<<63 - 1) / int64(time.Minute))
+
+func configuredSecureSessionDuration() time.Duration {
+	minutes := settings.AuthSettings.SecureSessionTimeoutMinutes
+	if minutes <= 0 || minutes > maxSecureSessionTimeoutMinutes {
+		return DefaultSecureSessionDuration
+	}
+	return time.Duration(minutes) * time.Minute
+}
 
 func SetSecureSessionID(userId uint64) (sessionId string) {
 	sessionId = uuid.NewString()

--- a/internal/user/secure_session.go
+++ b/internal/user/secure_session.go
@@ -5,9 +5,8 @@ package user
 import "time"
 
 // SecureSessionDuration is how long a verified two-factor session is accepted.
-// Release builds keep it fixed so the window cannot be widened at runtime.
 func SecureSessionDuration() time.Duration {
-	return DefaultSecureSessionDuration
+	return configuredSecureSessionDuration()
 }
 
 // storeSecureSession keeps the session in memory only, so restarting the

--- a/internal/user/secure_session_dev.go
+++ b/internal/user/secure_session_dev.go
@@ -26,14 +26,14 @@ const MaxDevSecureSessionDuration = 24 * time.Hour
 func SecureSessionDuration() time.Duration {
 	raw := os.Getenv(SecureSessionDurationEnv)
 	if raw == "" {
-		return DefaultSecureSessionDuration
+		return configuredSecureSessionDuration()
 	}
 
 	minutes := cast.ToInt(raw)
 	if minutes <= 0 {
 		logger.Warnf("%s=%q is not a positive number of minutes, falling back to %s",
 			SecureSessionDurationEnv, raw, DefaultSecureSessionDuration)
-		return DefaultSecureSessionDuration
+		return configuredSecureSessionDuration()
 	}
 
 	// Clamp before converting so a huge value cannot overflow the int64.

--- a/internal/user/secure_session_dev_test.go
+++ b/internal/user/secure_session_dev_test.go
@@ -5,6 +5,8 @@ package user
 import (
 	"testing"
 	"time"
+
+	"github.com/0xJacky/Nginx-UI/settings"
 )
 
 func TestSecureSessionDurationDevOverride(t *testing.T) {
@@ -39,5 +41,18 @@ func TestSecureSessionDurationDevRejectsOverflowingValue(t *testing.T) {
 	}
 	if got <= 0 {
 		t.Fatalf("duration must stay positive, got %s", got)
+	}
+}
+
+func TestSecureSessionDurationDevUsesAuthSettingWithoutOverride(t *testing.T) {
+	originalTimeout := settings.AuthSettings.SecureSessionTimeoutMinutes
+	t.Cleanup(func() {
+		settings.AuthSettings.SecureSessionTimeoutMinutes = originalTimeout
+	})
+	settings.AuthSettings.SecureSessionTimeoutMinutes = 60
+	t.Setenv(SecureSessionDurationEnv, "")
+
+	if got := SecureSessionDuration(); got != time.Hour {
+		t.Fatalf("duration = %s, want 1h from auth setting", got)
 	}
 }

--- a/internal/user/secure_session_test.go
+++ b/internal/user/secure_session_test.go
@@ -4,12 +4,39 @@ package user
 
 import (
 	"testing"
+	"time"
+
+	"github.com/0xJacky/Nginx-UI/settings"
 )
 
 func TestSecureSessionDurationIgnoresEnvInReleaseBuilds(t *testing.T) {
+	originalTimeout := settings.AuthSettings.SecureSessionTimeoutMinutes
+	t.Cleanup(func() {
+		settings.AuthSettings.SecureSessionTimeoutMinutes = originalTimeout
+	})
+	settings.AuthSettings.SecureSessionTimeoutMinutes = 10
 	t.Setenv("NGINX_UI_DEV_SECURE_SESSION_MINUTES", "600")
 
 	if got := SecureSessionDuration(); got != DefaultSecureSessionDuration {
 		t.Fatalf("duration = %s, want the fixed %s", got, DefaultSecureSessionDuration)
+	}
+}
+
+func TestSecureSessionDurationUsesValidatedAuthSetting(t *testing.T) {
+	originalTimeout := settings.AuthSettings.SecureSessionTimeoutMinutes
+	t.Cleanup(func() {
+		settings.AuthSettings.SecureSessionTimeoutMinutes = originalTimeout
+	})
+
+	settings.AuthSettings.SecureSessionTimeoutMinutes = 60
+	if got := SecureSessionDuration(); got != time.Hour {
+		t.Fatalf("duration = %s, want 1h from auth setting", got)
+	}
+
+	for _, invalid := range []int{0, -1} {
+		settings.AuthSettings.SecureSessionTimeoutMinutes = invalid
+		if got := SecureSessionDuration(); got != DefaultSecureSessionDuration {
+			t.Fatalf("duration for invalid value %d = %s, want %s", invalid, got, DefaultSecureSessionDuration)
+		}
 	}
 }

--- a/settings/auth.go
+++ b/settings/auth.go
@@ -1,13 +1,17 @@
 package settings
 
 type Auth struct {
-	IPWhiteList         []string `json:"ip_white_list" binding:"omitempty,dive,ip|redacted" ini:",,allowshadow" protected:"true"`
-	TrustedProxies      []string `json:"trusted_proxies" binding:"omitempty,dive,ip|cidr|redacted" ini:",,allowshadow" protected:"true"`
-	BanThresholdMinutes int      `json:"ban_threshold_minutes" binding:"min=1"`
-	MaxAttempts         int      `json:"max_attempts" binding:"min=1"`
+	IPWhiteList                 []string `json:"ip_white_list" binding:"omitempty,dive,ip|redacted" ini:",,allowshadow" protected:"true"`
+	TrustedProxies              []string `json:"trusted_proxies" binding:"omitempty,dive,ip|cidr|redacted" ini:",,allowshadow" protected:"true"`
+	BanThresholdMinutes         int      `json:"ban_threshold_minutes" binding:"min=1"`
+	MaxAttempts                 int      `json:"max_attempts" binding:"min=1"`
+	SecureSessionTimeoutMinutes int      `json:"secure_session_timeout_minutes" binding:"min=1"`
 }
 
+const DefaultSecureSessionTimeoutMinutes = 10
+
 var AuthSettings = &Auth{
-	BanThresholdMinutes: 10,
-	MaxAttempts:         10,
+	BanThresholdMinutes:         10,
+	MaxAttempts:                 10,
+	SecureSessionTimeoutMinutes: DefaultSecureSessionTimeoutMinutes,
 }

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -106,6 +106,10 @@ func Init(confPath string) {
 	if AuthSettings.MaxAttempts <= 0 {
 		AuthSettings.MaxAttempts = 10
 	}
+
+	if AuthSettings.SecureSessionTimeoutMinutes <= 0 {
+		AuthSettings.SecureSessionTimeoutMinutes = DefaultSecureSessionTimeoutMinutes
+	}
 }
 
 func Update(fn func()) (err error) {

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -28,6 +28,7 @@ func TestSetup(t *testing.T) {
 	_ = os.Setenv("NGINX_UI_AUTH_TRUSTED_PROXIES", "127.0.0.1,10.0.0.0/8,2001:db8::/32")
 	_ = os.Setenv("NGINX_UI_AUTH_BAN_THRESHOLD_MINUTES", "20")
 	_ = os.Setenv("NGINX_UI_AUTH_MAX_ATTEMPTS", "20")
+	_ = os.Setenv("NGINX_UI_AUTH_SECURE_SESSION_TIMEOUT_MINUTES", "60")
 
 	// Casdoor
 	_ = os.Setenv("NGINX_UI_CASDOOR_ENDPOINT", "https://casdoor.example.com")
@@ -123,6 +124,7 @@ func TestSetup(t *testing.T) {
 	assert.Equal(t, []string{"127.0.0.1", "10.0.0.0/8", "2001:db8::/32"}, AuthSettings.TrustedProxies)
 	assert.Equal(t, 20, AuthSettings.BanThresholdMinutes)
 	assert.Equal(t, 20, AuthSettings.MaxAttempts)
+	assert.Equal(t, 60, AuthSettings.SecureSessionTimeoutMinutes)
 
 	// Casdoor
 	assert.Equal(t, "https://casdoor.example.com", CasdoorSettings.Endpoint)


### PR DESCRIPTION
Closes #1827.

Adds `[auth] SecureSessionTimeoutMinutes` and the corresponding environment variable for the TOTP/passkey protected-operation window. The existing 10-minute behavior remains the default and invalid runtime values safely fall back to it; the development-only override still takes precedence.

This changes only the short-lived secure-session authorization window, not the normal login session lifetime.

Validation:
- `GOWORK=off go test -tags=unembed ./internal/user ./settings -run 'SecureSessionDuration|TestSetup' -count=1`
- `GOWORK=off go test -tags='dev unembed' ./internal/user -run SecureSessionDuration -count=1`
- `GOWORK=off go test -tags=unembed -race -cover -count=1 ./...`
- `git diff --check`
