### PR TITLE
feat(site): auto-match full DNS record names

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -65,3 +65,10 @@ bun run typecheck
 ```sh
 bun run build
 ```
+
+## DNS Record Matching
+
+The site editor matches DNS records against the normalized full `server_name`.
+Root (`@`), relative, wildcard, and provider-returned fully qualified record
+names are normalized before exact comparison so unrelated records are not
+selected automatically.

--- a/app/src/utils/dnsRecordMatching.ts
+++ b/app/src/utils/dnsRecordMatching.ts
@@ -1,0 +1,33 @@
+import type { DNSRecord } from '@/api/dns'
+
+function normalizeDnsName(name: string): string {
+  return name.trim().replace(/\.+$/, '').toLowerCase()
+}
+
+function getRecordDnsName(recordName: string, domain: string): string {
+  const normalizedDomain = normalizeDnsName(domain)
+  const normalizedRecord = normalizeDnsName(recordName)
+
+  if (normalizedRecord === '@' || normalizedRecord === normalizedDomain)
+    return normalizedDomain
+
+  if (normalizedRecord.endsWith(`.${normalizedDomain}`))
+    return normalizedRecord
+
+  return `${normalizedRecord}.${normalizedDomain}`
+}
+
+/** Return all record IDs that exactly serve the first configured server name. */
+export function findMatchingDNSRecordIds(
+  serverName: string,
+  domain: string,
+  records: DNSRecord[],
+): string[] {
+  const targetName = normalizeDnsName(serverName.split(/\s+/)[0] ?? '')
+  if (!targetName)
+    return []
+
+  return records
+    .filter(record => getRecordDnsName(record.name, domain) === targetName)
+    .map(record => record.id)
+}

--- a/app/src/views/site/site_edit/components/RightPanel/DNS.vue
+++ b/app/src/views/site/site_edit/components/RightPanel/DNS.vue
@@ -7,6 +7,7 @@ import { Tag } from 'antdv-next'
 import { Fragment, h } from 'vue'
 import { isAllowedDnsProvider } from '@/constants/dns_providers'
 import { useDnsStore } from '@/pinia/moudule/dns'
+import { findMatchingDNSRecordIds } from '@/utils/dnsRecordMatching'
 import { useSiteEditorStore } from '../SiteEditor/store'
 
 const { message } = useGlobalApp()
@@ -353,6 +354,11 @@ async function autoMatchDomain() {
       if (matchingDomain) {
         selectedDomainId.value = matchingDomain.id
         await loadRecordsForDomain(matchingDomain.id)
+        selectedRecordIds.value = findMatchingDNSRecordIds(
+          serverNameValue.value,
+          matchingDomain.domain,
+          availableRecords.value,
+        )
       }
     }
   }

--- a/app/tests/dnsRecordMatching.test.ts
+++ b/app/tests/dnsRecordMatching.test.ts
@@ -1,0 +1,42 @@
+import type { DNSRecord } from '../src/api/dns'
+import { describe, expect, test } from 'bun:test'
+import { findMatchingDNSRecordIds } from '../src/utils/dnsRecordMatching'
+
+function record(id: string, name: string, type = 'A'): DNSRecord {
+  return { id, name, type, content: '192.0.2.1', ttl: 600 }
+}
+
+describe('DNS record matching', () => {
+  test('selects every record whose full name matches server_name', () => {
+    const records = [
+      record('root', '@'),
+      record('www-a', 'www'),
+      record('www-aaaa', 'www', 'AAAA'),
+      record('api', 'api'),
+    ]
+
+    expect(findMatchingDNSRecordIds('www.example.com', 'example.com', records))
+      .toEqual(['www-a', 'www-aaaa'])
+  })
+
+  test('matches root, wildcard, and provider-returned fully qualified names', () => {
+    const records = [
+      record('root', '@'),
+      record('wildcard', '*'),
+      record('fqdn', 'WWW.Example.COM.'),
+    ]
+
+    expect(findMatchingDNSRecordIds('example.com.', 'Example.COM', records)).toEqual(['root'])
+    expect(findMatchingDNSRecordIds('*.example.com', 'example.com.', records)).toEqual(['wildcard'])
+    expect(findMatchingDNSRecordIds('www.example.com', 'example.com', records)).toEqual(['fqdn'])
+  })
+
+  test('does not select suffix or unrelated records', () => {
+    const records = [
+      record('partial', 'notwww'),
+      record('foreign', 'www.other.example'),
+    ]
+
+    expect(findMatchingDNSRecordIds('www.example.com', 'example.com', records)).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #1838.

After the site editor auto-matches a DNS domain, it now also selects every A, AAAA, or CNAME record whose normalized full name exactly matches the first `server_name`. Matching handles root (`@`), relative, wildcard, case-insensitive, trailing-dot, and provider-returned fully qualified names without selecting suffix lookalikes.

Validation:
- Regression test failed before the matching helper existed
- `bun test tests` (28 passed)
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `git diff --check`
