### PR TITLE
fix(nginx): a # inside a comment body is deleted on a config round trip

### DIFF
--- a/internal/nginx/build_config_test.go
+++ b/internal/nginx/build_config_test.go
@@ -76,3 +76,88 @@ func TestBuildConfig_UpstreamPerDirectiveComments(t *testing.T) {
 		t.Fatalf("BuildConfig() placed %q after the uncommented server:\n%s", "# second", built)
 	}
 }
+
+// hasCommentLine reports whether built contains comment as a whole line,
+// ignoring the indentation the dumper chooses.
+func hasCommentLine(built, comment string) bool {
+	for _, line := range strings.Split(built, "\n") {
+		if strings.TrimSpace(line) == comment {
+			return true
+		}
+	}
+	return false
+}
+
+// TestBuildConfig_CommentKeepsInnerHash guards the # characters that belong to
+// the comment text, such as a URL fragment or an issue number. The four places
+// a comment is read are covered: server, location, directive and upstream.
+func TestBuildConfig_CommentKeepsInnerHash(t *testing.T) {
+	content := `# server #0 terminates TLS
+server {
+    # see https://example.com/docs#tls
+    listen 80;
+
+    # route #1 of #2
+    location / {
+        proxy_pass http://backend;
+    }
+}
+
+upstream backend {
+    # shard #2 of #3
+    server 10.0.0.1:8080;
+}
+`
+
+	ngxConfig, err := ParseNgxConfigByContent(content)
+	if err != nil {
+		t.Fatalf("ParseNgxConfigByContent() error = %v", err)
+	}
+
+	built, err := ngxConfig.BuildConfig()
+	if err != nil {
+		t.Fatalf("BuildConfig() error = %v", err)
+	}
+
+	for _, comment := range []string{
+		"# server #0 terminates TLS",
+		"# see https://example.com/docs#tls",
+		"# route #1 of #2",
+		"# shard #2 of #3",
+	} {
+		if !hasCommentLine(built, comment) {
+			t.Fatalf("BuildConfig() = %q, want it to contain the line %q", built, comment)
+		}
+	}
+}
+
+// TestBuildConfig_CommentMarkerIsNormalised pins the marker handling that was
+// already in place, so only the comment text changes.
+func TestBuildConfig_CommentMarkerIsNormalised(t *testing.T) {
+	content := `server {
+    ## double marker
+    listen 80;
+}
+
+upstream backend {
+    #no space
+    server 10.0.0.1:8080;
+}
+`
+
+	ngxConfig, err := ParseNgxConfigByContent(content)
+	if err != nil {
+		t.Fatalf("ParseNgxConfigByContent() error = %v", err)
+	}
+
+	built, err := ngxConfig.BuildConfig()
+	if err != nil {
+		t.Fatalf("BuildConfig() error = %v", err)
+	}
+
+	for _, comment := range []string{"# double marker", "# no space"} {
+		if !hasCommentLine(built, comment) {
+			t.Fatalf("BuildConfig() = %q, want it to contain the line %q", built, comment)
+		}
+	}
+}

--- a/internal/nginx/parse.go
+++ b/internal/nginx/parse.go
@@ -168,8 +168,14 @@ func (c *NgxConfig) parseCustom(directive config.IDirective) {
 	c.Custom += "}\n"
 }
 
+// buildComment drops the leading marker only. buildComments re-adds one when
+// the config is written back, so a # inside the body has to survive.
 func buildComment(c []string) string {
-	return strings.ReplaceAll(strings.Join(c, "\n"), "#", "")
+	lines := make([]string, 0, len(c))
+	for _, line := range c {
+		lines = append(lines, strings.TrimLeft(line, "#"))
+	}
+	return strings.Join(lines, "\n")
 }
 
 func shouldUnwrapRootBlock(block config.IBlock) config.IDirective {


### PR DESCRIPTION
`buildComment` strips every `#` from a comment, not just the leading marker, so any `#` that belongs to the comment text is deleted when a site is opened in the block editor and saved.

```
in : # see https://example.com/docs#tls      in : # shard #2 of #3
out: # see https://example.com/docstls       out: # shard 2 of 3
```

gonginx returns each comment line with its marker attached, and `buildComments` in `build_config.go` re-adds exactly one `#` when the config is written back. So the marker has to come off, but only the marker. The pairing is what makes this provable rather than a matter of taste.

The path is `GET` the site, edit in block mode, `POST ngx/build_config`. Both halves are in this repo, so a user loses the text without touching it.

Output is byte-identical to before for every input that has no `#` after the leading marker run. `## double marker` still normalises to `# double marker` and `#no space` still becomes `# no space`, which is why the second test is there: it pins the behaviour that must not change.

Verification, all run locally:

- Four cases in `TestBuildConfig_CommentKeepsInnerHash` cover the four places a comment is read (server, location, directive, upstream). Reverting any one of the four `buildComment` call sites to the old stripping fails that test and nothing else.
- Reverting `TrimLeft` to `TrimPrefix`, so only one marker comes off, fails `TestBuildConfig_CommentMarkerIsNormalised` and nothing else.
- Boundary inputs through the full parse and build round trip: an empty comment, markers only, no marker, `;` and `}` inside the text, a multi-line block, and a multi-byte emoji. Every result reparses cleanly.
- `GOWORK=off go test -tags=unembed -race -cover -count=1 ./...` is unchanged. Five tests fail on this machine both with and without the patch, in `internal/config`, `internal/site` and `internal/stream`, because there is no nginx binary here. Identical set on a clean tree.
- `gofmt` clean.

One thing I did not fix, since it is next door rather than in this change. `buildComments` reads with a `bufio.Scanner`, so a comment over 64 KiB is silently dropped. That is pre-existing, and keeping the `#` characters makes such a comment slightly longer, so the change widens an existing window very slightly. `indentRawDirective` in the same file already avoids `bufio.Scanner` for exactly this reason. Happy to do it separately if you want it.

AI disclosure: written with Claude Code. I ran the round trip before and after, ran the mutations, and checked the boundary inputs myself.
