### PR TITLE
fix(nginx): a backslash in a rewritten directive value corrupts the config

### DIFF
--- a/internal/nginx/directive_values.go
+++ b/internal/nginx/directive_values.go
@@ -98,13 +98,18 @@ func renderDirectiveValue(original, value string) (string, error) {
 
 	switch original[0] {
 	case '\'':
-		return "'" + strings.ReplaceAll(value, "'", "\\'") + "'", nil
+		escaped := strings.ReplaceAll(value, `\`, `\\`)
+		escaped = strings.ReplaceAll(escaped, "'", `\'`)
+		return "'" + escaped + "'", nil
 	case '"':
 		escaped := strings.ReplaceAll(value, `\`, `\\`)
 		escaped = strings.ReplaceAll(escaped, `"`, `\"`)
 		return `"` + escaped + `"`, nil
 	default:
-		if strings.ContainsAny(value, " \t\r\n#{};") {
+		// A backslash escapes the next character, so leaving one bare lets it
+		// swallow the terminating semicolon. An empty value needs the quotes to
+		// stay an argument at all.
+		if value == "" || strings.ContainsAny(value, " \t\r\n#{};\\") {
 			escaped := strings.ReplaceAll(value, `\`, `\\`)
 			escaped = strings.ReplaceAll(escaped, `"`, `\"`)
 			return `"` + escaped + `"`, nil

--- a/internal/nginx/directive_values_test.go
+++ b/internal/nginx/directive_values_test.go
@@ -36,6 +36,60 @@ server {
 	}
 }
 
+// TestRewriteDirectiveValuesEscapesBackslash keeps a rewritten value readable
+// back as itself, whichever form the original directive used. A backslash is an
+// escape inside both quote styles and outside them, so leaving one bare loses a
+// character, or lets it swallow the closing quote or the semicolon.
+func TestRewriteDirectiveValuesEscapesBackslash(t *testing.T) {
+	// The empty value only has somewhere to go once the directive is quoted,
+	// so it is not a case for the already-quoted forms.
+	quoted := []string{
+		`/etc/ssl/a\b/key.pem`,
+		`/etc/ssl/a\\b/key.pem`,
+		`/etc/ssl/a\tb/key.pem`,
+		`/etc/ssl/o'brien/key.pem`,
+		`/etc/ssl/say"hi"/key.pem`,
+		`/etc/ssl/trailing\`,
+	}
+
+	for _, tt := range []struct {
+		name     string
+		original string
+		values   []string
+	}{
+		{"single quoted", "'/old/key.pem'", quoted},
+		{"double quoted", `"/old/key.pem"`, quoted},
+		{"unquoted", "/old/key.pem", append(append([]string{}, quoted...), "")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, newValue := range tt.values {
+				content := "server {\n    ssl_certificate_key " + tt.original + ";\n}\n"
+
+				rewritten, count, err := RewriteDirectiveValues(content, []DirectiveValueReplacement{
+					{Directive: "ssl_certificate_key", OldValue: "/old/key.pem", NewValue: newValue},
+				})
+				if err != nil {
+					t.Errorf("RewriteDirectiveValues(%q) error = %v", newValue, err)
+					continue
+				}
+				if count != 1 {
+					t.Errorf("RewriteDirectiveValues(%q) count = %d, want 1", newValue, count)
+					continue
+				}
+
+				values, err := DirectiveValues(rewritten, "ssl_certificate_key")
+				if err != nil {
+					t.Errorf("DirectiveValues(%q) error = %v, rewritten:\n%s", newValue, err, rewritten)
+					continue
+				}
+				if len(values) != 1 || values[0] != newValue {
+					t.Errorf("round trip gave %#v, want [%q], rewritten:\n%s", values, newValue, rewritten)
+				}
+			}
+		})
+	}
+}
+
 func TestDirectiveValuesIgnoresCommentsAndOtherDirectives(t *testing.T) {
 	content := `
 # ssl_certificate /commented/cert.pem;


### PR DESCRIPTION
`renderDirectiveValue` does not escape backslashes, so the certificate path migration can write a config that says something other than the path it was given, or that nginx cannot parse at all.

Reached from `internal/site/certificate_migration.go:307` through `RewriteDirectiveValues`, where `NewValue` is `certModel.SSLCertificatePath`, a path the user sets.

The unquoted form is the one real configs use, and it is the worst of the three:

```
ssl_certificate_key /old/key.pem;        new value: /etc/ssl/trailing\
before: ssl_certificate_key /etc/ssl/trailing\;      the backslash eats the ';'

ssl_certificate_key /old/key.pem;        new value: (empty)
before: ssl_certificate_key ;                        directive with no argument

ssl_certificate_key /old/key.pem;        new value: /etc/ssl/a\b/key.pem
before: reads back as /etc/ssl/ab/key.pem
```

Single-quoted values have the same root cause:

```
ssl_certificate_key '/old/key.pem';      new value: /etc/ssl/trailing\
before: ssl_certificate_key '/etc/ssl/trailing\';    unterminated quoted string
```

The `case '"'` branch three lines below already escapes the backslash first and then the quote, and `quoteNginxPath` in `sandbox.go` does the same. The single-quote branch now matches them, and the unquoted branch treats a backslash and an empty value as reasons to quote.

I checked this against nginx itself rather than only against this repo's tokenizer, because they do not agree. nginx recognises `\" \' \\ \t \r \n` and preserves anything else, so a plain `a\b` was already fine for nginx and only this repo's reader dropped it. The cases that were broken for nginx too are the trailing backslash, a value containing a literal `\\` or `\t`, and the empty value. The change is correct under both readers, and produces the same bytes as before for any value with no backslash and no `'`.

Verification:

- Table test over three original forms and six values each, asserting the full `RewriteDirectiveValues` then `DirectiveValues` round trip rather than a substring.
- Reverting the single-quote branch fails only the `single quoted` subtest. Reverting the unquoted branch fails only the `unquoted` subtest.
- `GOWORK=off go test -tags=unembed -race -cover -count=1 ./...` has the same five failures with and without the patch, in `internal/config`, `internal/site` and `internal/stream`. They are a file-mode assertion and a missing nginx binary on this machine, identical on a clean tree.
- `gofmt` clean.

Not addressed, and worth knowing. A user who already ran the migration with a backslash in the path has a file whose value decodes differently from the database, so `valueToken.value == OldValue` no longer matches and the site stays flagged as mismatched with `count=0` and no error. This patch stops new damage but does not repair that. Tell me if you want the repair in here too and I will add it.

AI disclosure: written with Claude Code. I ran the round trips before and after, checked nginx's own lexer behaviour, and ran the mutations myself.
