### PR TITLE
feat: add maintenance support with additional information

### DIFF
--- a/api/pages/maintenance.go
+++ b/api/pages/maintenance.go
@@ -19,14 +19,23 @@ var tmplFS embed.FS
 // maintenanceSiteHeader carries the site name injected by the generated
 // maintenance nginx configuration, so a per-site template can be selected.
 const maintenanceSiteHeader = "X-Maintenance-Site"
+const maintenanceStartTimeHeader = "X-Maintenance-Start-Time"
+const maintenanceEndTimeHeader = "X-Maintenance-End-Time"
+const maintenanceContactHeader = "X-Maintenance-Contact"
+const maintenanceAdditionalInfoHeader = "X-Maintenance-Additional-Information"
 
 // MaintenancePageData maintenance page data structure
 type MaintenancePageData struct {
-	Title                string `json:"title"`
-	Message              string `json:"message"`
-	Description          string `json:"description"`
-	ICPNumber            string `json:"icp_number"`
-	PublicSecurityNumber string `json:"public_security_number"`
+	Title                 string `json:"title"`
+	Message               string `json:"message"`
+	Description           string `json:"description"`
+	ICPNumber             string `json:"icp_number"`
+	PublicSecurityNumber  string `json:"public_security_number"`
+	SiteName              string `json:"site_name"`
+	StartTime             string `json:"start_time"`
+	EndTime               string `json:"end_time"`
+	Contact               string `json:"contact"`
+	AdditionalInformation string `json:"additioninfomation"`
 }
 
 const (
@@ -39,11 +48,16 @@ const (
 func MaintenancePage(c *gin.Context) {
 	// Prepare template data
 	data := MaintenancePageData{
-		Title:                Title,
-		Message:              Message,
-		Description:          Description,
-		ICPNumber:            settings.NodeSettings.ICPNumber,
-		PublicSecurityNumber: settings.NodeSettings.PublicSecurityNumber,
+		Title:                 Title,
+		Message:               Message,
+		Description:           Description,
+		ICPNumber:             settings.NodeSettings.ICPNumber,
+		PublicSecurityNumber:  settings.NodeSettings.PublicSecurityNumber,
+		SiteName:              strings.TrimSpace(c.GetHeader(maintenanceSiteHeader)),
+		StartTime:             strings.TrimSpace(c.GetHeader(maintenanceStartTimeHeader)),
+		EndTime:               strings.TrimSpace(c.GetHeader(maintenanceEndTimeHeader)),
+		Contact:               strings.TrimSpace(c.GetHeader(maintenanceContactHeader)),
+		AdditionalInformation: strings.TrimSpace(c.GetHeader(maintenanceAdditionalInfoHeader)),
 	}
 
 	// Check User-Agent
@@ -84,6 +98,17 @@ func MaintenancePage(c *gin.Context) {
 		c.String(http.StatusInternalServerError, "503 Service Unavailable")
 		return
 	}
+}
+
+// MaintenanceMeta returns maintenance metadata used by custom HTML/JS pages.
+func MaintenanceMeta(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{
+		"site_name":          strings.TrimSpace(c.GetHeader(maintenanceSiteHeader)),
+		"start_time":         strings.TrimSpace(c.GetHeader(maintenanceStartTimeHeader)),
+		"end_time":           strings.TrimSpace(c.GetHeader(maintenanceEndTimeHeader)),
+		"contact":            strings.TrimSpace(c.GetHeader(maintenanceContactHeader)),
+		"additioninfomation": strings.TrimSpace(c.GetHeader(maintenanceAdditionalInfoHeader)),
+	})
 }
 
 // Helper function to check if a string contains a substring

--- a/api/pages/maintenance.tmpl
+++ b/api/pages/maintenance.tmpl
@@ -67,6 +67,33 @@
             color: #999;
             border-top: 1px solid #f0f0f0;
         }
+
+        .maintenance-meta {
+            margin-top: 20px;
+            text-align: left;
+            border: 1px solid #f0f0f0;
+            border-radius: 8px;
+            padding: 14px 16px;
+            background: #fafafa;
+        }
+
+        .maintenance-meta-item {
+            margin: 0;
+            color: #555;
+            font-size: 14px;
+            line-height: 1.6;
+            word-break: break-word;
+        }
+
+        .maintenance-meta-item + .maintenance-meta-item {
+            margin-top: 6px;
+        }
+
+        .maintenance-meta-label {
+            color: #222;
+            font-weight: 600;
+            margin-right: 8px;
+        }
         
         .footer p {
             margin: 0;
@@ -135,6 +162,12 @@
             <h1>{{.Title}}</h1>
             <p>{{.Message}}</p>
             <p>{{.Description}}</p>
+            <div id="maintenance-meta" class="maintenance-meta" style="display: none;">
+                <p id="maintenance-start" class="maintenance-meta-item" style="display: none;"><span class="maintenance-meta-label">Start:</span><span id="maintenance-start-value"></span></p>
+                <p id="maintenance-end" class="maintenance-meta-item" style="display: none;"><span class="maintenance-meta-label">End:</span><span id="maintenance-end-value"></span></p>
+                <p id="maintenance-contact" class="maintenance-meta-item" style="display: none;"><span class="maintenance-meta-label">Contact:</span><span id="maintenance-contact-value"></span></p>
+                <p id="maintenance-additional" class="maintenance-meta-item" style="display: none;"><span class="maintenance-meta-label">Additional:</span><span id="maintenance-additional-value"></span></p>
+            </div>
             <div class="footer">
                 <p>Powered by <a href="https://nginxui.com" target="_blank">Nginx UI</a></p>
             </div>
@@ -148,5 +181,52 @@
             {{end}}
         </div>
     </div>
+    <script>
+        (function () {
+            function showField(wrapperId, valueId, value) {
+                if (!value) {
+                    return false
+                }
+
+                var wrapper = document.getElementById(wrapperId)
+                var valueElement = document.getElementById(valueId)
+                if (!wrapper || !valueElement) {
+                    return false
+                }
+
+                valueElement.textContent = value
+                wrapper.style.display = 'block'
+                return true
+            }
+
+            fetch('/pages/maintenance/meta', {
+                headers: {
+                    'Accept': 'application/json'
+                }
+            }).then(function (response) {
+                if (!response.ok) {
+                    return null
+                }
+                return response.json()
+            }).then(function (data) {
+                if (!data) {
+                    return
+                }
+
+                var hasAny = false
+                hasAny = showField('maintenance-start', 'maintenance-start-value', data.start_time) || hasAny
+                hasAny = showField('maintenance-end', 'maintenance-end-value', data.end_time) || hasAny
+                hasAny = showField('maintenance-contact', 'maintenance-contact-value', data.contact) || hasAny
+                hasAny = showField('maintenance-additional', 'maintenance-additional-value', data.additioninfomation) || hasAny
+
+                var meta = document.getElementById('maintenance-meta')
+                if (meta && hasAny) {
+                    meta.style.display = 'block'
+                }
+            }).catch(function () {
+                // Keep the page functional even if metadata cannot be fetched.
+            })
+        })()
+    </script>
 </body>
 </html>

--- a/api/pages/maintenance_test.go
+++ b/api/pages/maintenance_test.go
@@ -1,11 +1,15 @@
 package pages
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/0xJacky/Nginx-UI/settings"
+	"github.com/gin-gonic/gin"
 )
 
 func setupMaintenanceTemplateSettings(t *testing.T, dir, template string) {
@@ -95,5 +99,45 @@ func TestSanitizeMaintenanceFileNameRejectsTraversal(t *testing.T) {
 				t.Fatalf("sanitizeMaintenanceFileName(%q) = %q, want %q", test.input, got, test.want)
 			}
 		})
+	}
+}
+
+func TestMaintenanceMeta(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest(http.MethodGet, "/pages/maintenance/meta", nil)
+	req.Header.Set(maintenanceSiteHeader, "example.com")
+	req.Header.Set(maintenanceStartTimeHeader, "2026-09-09 10:00:00")
+	req.Header.Set(maintenanceEndTimeHeader, "2026-09-09 12:00:00")
+	req.Header.Set(maintenanceContactHeader, "ops@example.com")
+	req.Header.Set(maintenanceAdditionalInfoHeader, "planned db migration")
+	c.Request = req
+
+	MaintenanceMeta(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("MaintenanceMeta() status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if payload["site_name"] != "example.com" {
+		t.Fatalf("site_name = %q, want %q", payload["site_name"], "example.com")
+	}
+	if payload["start_time"] != "2026-09-09 10:00:00" {
+		t.Fatalf("start_time = %q, want %q", payload["start_time"], "2026-09-09 10:00:00")
+	}
+	if payload["end_time"] != "2026-09-09 12:00:00" {
+		t.Fatalf("end_time = %q, want %q", payload["end_time"], "2026-09-09 12:00:00")
+	}
+	if payload["contact"] != "ops@example.com" {
+		t.Fatalf("contact = %q, want %q", payload["contact"], "ops@example.com")
+	}
+	if payload["additioninfomation"] != "planned db migration" {
+		t.Fatalf("additioninfomation = %q, want %q", payload["additioninfomation"], "planned db migration")
 	}
 }

--- a/api/pages/router.go
+++ b/api/pages/router.go
@@ -8,4 +8,5 @@ import (
 func InitRouter(r *gin.Engine) {
 	// Register maintenance page route
 	r.GET("/pages/maintenance", MaintenancePage)
+	r.GET("/pages/maintenance/meta", MaintenanceMeta)
 }

--- a/api/sites/site.go
+++ b/api/sites/site.go
@@ -2,6 +2,8 @@ package sites
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -379,7 +381,7 @@ func disableSiteByName(name string) error {
 	return site.Disable(name)
 }
 
-func enableMaintenanceByName(name string) error {
+func enableMaintenanceByName(name string, payload *site.MaintenancePayload) error {
 	// If site is already enabled, disable the normal site first.
 	enabledConfigPath, err := site.ResolveEnabledPath(name)
 	if err != nil {
@@ -396,7 +398,7 @@ func enableMaintenanceByName(name string) error {
 		}
 	}
 
-	return site.EnableMaintenance(name)
+	return site.EnableMaintenanceWithPayload(name, payload)
 }
 
 func EnableSite(c *gin.Context) {
@@ -480,16 +482,31 @@ func BatchDisableSites(c *gin.Context) {
 }
 
 func BatchEnableMaintenanceSites(c *gin.Context) {
-	var json batchSiteNamesRequest
+	type batchEnableMaintenanceRequest struct {
+		Names                 []string `json:"names" binding:"required,min=1"`
+		StartTime             string   `json:"start_time"`
+		EndTime               string   `json:"end_time"`
+		Contact               string   `json:"contact"`
+		AdditionalInformation string   `json:"additioninfomation"`
+	}
+
+	var json batchEnableMaintenanceRequest
 	if !cosy.BindAndValid(c, &json) {
 		return
+	}
+
+	payload := &site.MaintenancePayload{
+		StartTime:           json.StartTime,
+		EndTime:             json.EndTime,
+		Contact:             json.Contact,
+		AdditionInformation: json.AdditionalInformation,
 	}
 
 	for _, name := range json.Names {
 		if rejectInvalidSiteName(c, name) {
 			return
 		}
-		if err := enableMaintenanceByName(name); err != nil {
+		if err := enableMaintenanceByName(name, payload); err != nil {
 			cosy.ErrHandler(c, err)
 			return
 		}
@@ -571,7 +588,14 @@ func EnableMaintenanceSite(c *gin.Context) {
 		return
 	}
 
-	err := enableMaintenanceByName(name)
+	var req site.MaintenancePayload
+	err := c.ShouldBindJSON(&req)
+	if err != nil && !errors.Is(err, io.EOF) {
+		cosy.ErrHandler(c, err)
+		return
+	}
+
+	err = enableMaintenanceByName(name, &req)
 	if err != nil {
 		cosy.ErrHandler(c, err)
 		return

--- a/app/src/api/site.ts
+++ b/app/src/api/site.ts
@@ -66,6 +66,13 @@ export interface AutoCertRequest {
   revoke_old?: boolean
 }
 
+export interface MaintenancePayload {
+  start_time?: string
+  end_time?: string
+  contact?: string
+  additioninfomation?: string
+}
+
 const baseUrl = '/sites'
 
 const site = extendCurdApi(useCurdApi<Site>(baseUrl), {
@@ -73,14 +80,14 @@ const site = extendCurdApi(useCurdApi<Site>(baseUrl), {
   disable: (name: string) => http.post(`${baseUrl}/${encodeURIComponent(name)}/disable`),
   batchEnable: (names: string[]) => http.post(`${baseUrl}/batch/enable`, { names }),
   batchDisable: (names: string[]) => http.post(`${baseUrl}/batch/disable`, { names }),
-  batchEnableMaintenance: (names: string[]) => http.post(`${baseUrl}/batch/maintenance`, { names }),
+  batchEnableMaintenance: (names: string[], payload: MaintenancePayload = {}) => http.post(`${baseUrl}/batch/maintenance`, { names, ...payload }),
   rename: (oldName: string, newName: string) => http.post(`${baseUrl}/${encodeURIComponent(oldName)}/rename`, { new_name: newName }),
   get_default_template: () => http.get('default_site_template'),
   add_auto_cert: (domain: string, data: AutoCertRequest) => http.post(`auto_cert/${encodeURIComponent(domain)}`, data),
   remove_auto_cert: (domain: string) => http.delete(`auto_cert/${encodeURIComponent(domain)}`),
   duplicate: (name: string, data: { name: string }) => http.post(`${baseUrl}/${encodeURIComponent(name)}/duplicate`, data),
   advance_mode: (name: string, data: { advanced: boolean }) => http.post(`${baseUrl}/${encodeURIComponent(name)}/advance`, data),
-  enableMaintenance: (name: string) => http.post(`${baseUrl}/${encodeURIComponent(name)}/maintenance`),
+  enableMaintenance: (name: string, payload: MaintenancePayload = {}) => http.post(`${baseUrl}/${encodeURIComponent(name)}/maintenance`, payload),
   getLogs: (name: string) => http.get<{ logs: SiteLog[] }>(`${baseUrl}/${encodeURIComponent(name)}/logs`),
 })
 

--- a/app/src/language/en.po
+++ b/app/src/language/en.po
@@ -10858,6 +10858,50 @@ msgid ""
 "answered locally and never reach a server."
 msgstr ""
 
+#: src/views/site/components/MaintenanceConfigModal.vue:38
+msgid "End time must be later than start time"
+msgstr ""
+
+#: src/views/site/components/MaintenanceConfigModal.vue:62
+msgid "Set maintenance information"
+msgstr ""
+
+#: src/views/site/components/MaintenanceConfigModal.vue:71
+msgid "Start time"
+msgstr ""
+
+#: src/views/site/components/MaintenanceConfigModal.vue:76
+msgid "Select maintenance start time"
+msgstr ""
+
+#: src/views/site/components/MaintenanceConfigModal.vue:80
+msgid "End time"
+msgstr ""
+
+#: src/views/site/components/MaintenanceConfigModal.vue:86
+msgid "Select maintenance end time"
+msgstr ""
+
+#: src/views/site/components/MaintenanceConfigModal.vue:94
+msgid "For example: ops@example.com"
+msgstr ""
+
+#: src/views/site/components/MaintenanceConfigModal.vue:98
+msgid "Additional information"
+msgstr ""
+
+#: src/views/site/components/MaintenanceConfigModal.vue:103
+msgid "For example: expected recovery plan or incident reference"
+msgstr ""
+
+#: src/views/site/components/SiteStatusSelect.vue:195
+msgid "Set maintenance information for this site"
+msgstr ""
+
+#: src/views/site/site_list/SiteList.vue:290
+msgid "Set maintenance information for selected sites"
+msgstr ""
+
 #: src/views/terminal/Terminal.vue:256
 msgid ""
 "You are accessing this terminal over an insecure HTTP connection on a non-"

--- a/app/src/language/zh_CN.po
+++ b/app/src/language/zh_CN.po
@@ -12100,3 +12100,47 @@ msgstr "更新密码"
 #~ "Currently, DNS record management supports Alibaba Cloud DNS, Tencent Cloud "
 #~ "DNS, and Cloudflare only."
 #~ msgstr "目前，DNS 记录管理仅支持阿里云 DNS、腾讯云 DNS 和 Cloudflare。"
+
+#: src/views/site/components/MaintenanceConfigModal.vue:38
+msgid "End time must be later than start time"
+msgstr "结束时间必须晚于开始时间"
+
+#: src/views/site/components/MaintenanceConfigModal.vue:62
+msgid "Set maintenance information"
+msgstr "设置维护信息"
+
+#: src/views/site/components/MaintenanceConfigModal.vue:71
+msgid "Start time"
+msgstr "开始时间"
+
+#: src/views/site/components/MaintenanceConfigModal.vue:76
+msgid "Select maintenance start time"
+msgstr "请选择维护开始时间"
+
+#: src/views/site/components/MaintenanceConfigModal.vue:80
+msgid "End time"
+msgstr "结束时间"
+
+#: src/views/site/components/MaintenanceConfigModal.vue:86
+msgid "Select maintenance end time"
+msgstr "请选择维护结束时间"
+
+#: src/views/site/components/MaintenanceConfigModal.vue:94
+msgid "For example: ops@example.com"
+msgstr "例如：ops@example.com"
+
+#: src/views/site/components/MaintenanceConfigModal.vue:98
+msgid "Additional information"
+msgstr "附加信息"
+
+#: src/views/site/components/MaintenanceConfigModal.vue:103
+msgid "For example: expected recovery plan or incident reference"
+msgstr "例如：预计恢复方案或事件编号"
+
+#: src/views/site/components/SiteStatusSelect.vue:195
+msgid "Set maintenance information for this site"
+msgstr "为此站点设置维护信息"
+
+#: src/views/site/site_list/SiteList.vue:290
+msgid "Set maintenance information for selected sites"
+msgstr "为选中的站点设置维护信息"

--- a/app/src/language/zh_TW.po
+++ b/app/src/language/zh_TW.po
@@ -12033,3 +12033,47 @@ msgstr "更新密碼"
 #~ "Currently, DNS record management supports Alibaba Cloud DNS, Tencent Cloud "
 #~ "DNS, and Cloudflare only."
 #~ msgstr "目前，DNS 記錄管理僅支援阿里雲 DNS、騰訊雲 DNS 和 Cloudflare。"
+
+#: src/views/site/components/MaintenanceConfigModal.vue:38
+msgid "End time must be later than start time"
+msgstr "結束時間必須晚於開始時間"
+
+#: src/views/site/components/MaintenanceConfigModal.vue:62
+msgid "Set maintenance information"
+msgstr "設定維護資訊"
+
+#: src/views/site/components/MaintenanceConfigModal.vue:71
+msgid "Start time"
+msgstr "開始時間"
+
+#: src/views/site/components/MaintenanceConfigModal.vue:76
+msgid "Select maintenance start time"
+msgstr "請選擇維護開始時間"
+
+#: src/views/site/components/MaintenanceConfigModal.vue:80
+msgid "End time"
+msgstr "結束時間"
+
+#: src/views/site/components/MaintenanceConfigModal.vue:86
+msgid "Select maintenance end time"
+msgstr "請選擇維護結束時間"
+
+#: src/views/site/components/MaintenanceConfigModal.vue:94
+msgid "For example: ops@example.com"
+msgstr "例如：ops@example.com"
+
+#: src/views/site/components/MaintenanceConfigModal.vue:98
+msgid "Additional information"
+msgstr "附加資訊"
+
+#: src/views/site/components/MaintenanceConfigModal.vue:103
+msgid "For example: expected recovery plan or incident reference"
+msgstr "例如：預計復原方案或事件編號"
+
+#: src/views/site/components/SiteStatusSelect.vue:195
+msgid "Set maintenance information for this site"
+msgstr "為此站點設定維護資訊"
+
+#: src/views/site/site_list/SiteList.vue:290
+msgid "Set maintenance information for selected sites"
+msgstr "為選取的站點設定維護資訊"

--- a/app/src/views/site/components/MaintenanceConfigModal.vue
+++ b/app/src/views/site/components/MaintenanceConfigModal.vue
@@ -10,7 +10,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   'update:open': [value: boolean]
-  confirm: [payload: MaintenancePayload]
+  'confirm': [payload: MaintenancePayload]
 }>()
 
 const { message } = useGlobalApp()
@@ -48,7 +48,7 @@ function handleOk() {
   emit('update:open', false)
 }
 
-const disabledEndDate = (current: Dayjs) => {
+function disabledEndDate(current: Dayjs) {
   if (!startAt.value) {
     return false
   }

--- a/app/src/views/site/components/MaintenanceConfigModal.vue
+++ b/app/src/views/site/components/MaintenanceConfigModal.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import type { Dayjs } from 'dayjs'
+import type { MaintenancePayload } from '@/api/site'
+
+const props = defineProps<{
+  open: boolean
+  title?: string
+  okText?: string
+}>()
+
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+  confirm: [payload: MaintenancePayload]
+}>()
+
+const { message } = useGlobalApp()
+
+const startAt = ref<Dayjs | null>(null)
+const endAt = ref<Dayjs | null>(null)
+const contact = ref('')
+const additioninfomation = ref('')
+
+watch(() => props.open, open => {
+  if (!open) {
+    startAt.value = null
+    endAt.value = null
+    contact.value = ''
+    additioninfomation.value = ''
+  }
+})
+
+function handleCancel() {
+  emit('update:open', false)
+}
+
+function handleOk() {
+  if (startAt.value && endAt.value && endAt.value.isBefore(startAt.value)) {
+    message.error($gettext('End time must be later than start time'))
+    return
+  }
+
+  emit('confirm', {
+    start_time: startAt.value ? startAt.value.format('YYYY-MM-DD HH:mm:ss') : '',
+    end_time: endAt.value ? endAt.value.format('YYYY-MM-DD HH:mm:ss') : '',
+    contact: contact.value.trim(),
+    additioninfomation: additioninfomation.value.trim(),
+  })
+  emit('update:open', false)
+}
+
+const disabledEndDate = (current: Dayjs) => {
+  if (!startAt.value) {
+    return false
+  }
+  return current.isBefore(startAt.value)
+}
+</script>
+
+<template>
+  <AModal
+    :open="open"
+    :title="title || $gettext('Set maintenance information')"
+    :ok-text="okText || $gettext('Continue')"
+    :cancel-text="$gettext('Cancel')"
+    :mask="false"
+    centered
+    @ok="handleOk"
+    @cancel="handleCancel"
+  >
+    <AForm layout="vertical" class="pt-2">
+      <AFormItem :label="$gettext('Start time')">
+        <ADatePicker
+          v-model:value="startAt"
+          class="w-full"
+          show-time
+          :placeholder="$gettext('Select maintenance start time')"
+        />
+      </AFormItem>
+
+      <AFormItem :label="$gettext('End time')">
+        <ADatePicker
+          v-model:value="endAt"
+          class="w-full"
+          show-time
+          :disabled-date="disabledEndDate"
+          :placeholder="$gettext('Select maintenance end time')"
+        />
+      </AFormItem>
+
+      <AFormItem :label="$gettext('Contact')">
+        <AInput
+          v-model:value="contact"
+          :maxlength="128"
+          :placeholder="$gettext('For example: ops@example.com')"
+        />
+      </AFormItem>
+
+      <AFormItem :label="$gettext('Additional information')">
+        <ATextarea
+          v-model:value="additioninfomation"
+          :maxlength="500"
+          :auto-size="{ minRows: 2, maxRows: 5 }"
+          :placeholder="$gettext('For example: expected recovery plan or incident reference')"
+        />
+      </AFormItem>
+    </AForm>
+  </AModal>
+</template>

--- a/app/src/views/site/components/SiteStatusSelect.vue
+++ b/app/src/views/site/components/SiteStatusSelect.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import type { SelectProps, SelectValue } from 'antdv-next'
-import type { SiteStatus } from '@/api/site'
+import type { MaintenancePayload, SiteStatus } from '@/api/site'
 import { Modal } from 'antdv-next'
 import site from '@/api/site'
 import { ConfigStatus } from '@/constants'
+import MaintenanceConfigModal from '@/views/site/components/MaintenanceConfigModal.vue'
 
 // Define props with TypeScript
 const props = defineProps<{
@@ -22,6 +23,8 @@ const status = defineModel<string>({
 
 const { message } = useGlobalApp()
 const [modal, ContextHolder] = Modal.useModal()
+const maintenanceModalOpen = ref(false)
+const pendingMaintenanceOriginalStatus = ref<string>(ConfigStatus.Disabled)
 
 const statusOptions = computed<SelectProps['options']>(() => [
   {
@@ -90,8 +93,8 @@ function disable() {
 }
 
 // Enable maintenance mode for the site
-function enableMaintenance() {
-  site.enableMaintenance(props.siteName).then(() => {
+function enableMaintenance(payload: MaintenancePayload) {
+  site.enableMaintenance(props.siteName, payload).then(() => {
     message.success($gettext('Maintenance mode enabled successfully'))
     status.value = ConfigStatus.Maintenance
     emit('statusChanged', {
@@ -125,6 +128,12 @@ function onChangeStatus(value: SelectValue) {
   // Save original status to restore if user cancels
   const originalStatus = status.value
 
+  if (statusValue === ConfigStatus.Maintenance) {
+    pendingMaintenanceOriginalStatus.value = originalStatus
+    maintenanceModalOpen.value = true
+    return
+  }
+
   const statusMap = {
     [ConfigStatus.Enabled]: $gettext('enable'),
     [ConfigStatus.Disabled]: $gettext('disable'),
@@ -149,9 +158,6 @@ function onChangeStatus(value: SelectValue) {
       else if (statusValue === ConfigStatus.Disabled) {
         disable()
       }
-      else if (statusValue === ConfigStatus.Maintenance) {
-        enableMaintenance()
-      }
     },
     onCancel() {
       // Restore original status if user cancels
@@ -159,11 +165,39 @@ function onChangeStatus(value: SelectValue) {
     },
   })
 }
+
+function onMaintenanceConfirm(payload: MaintenancePayload) {
+  modal.confirm({
+    title: $gettext('Do you want to set this site to maintenance mode?'),
+    mask: false,
+    centered: true,
+    okText: $gettext('Maintenance'),
+    cancelText: $gettext('Cancel'),
+    onOk: () => enableMaintenance(payload),
+    onCancel: () => {
+      status.value = pendingMaintenanceOriginalStatus.value
+    },
+  })
+}
+
+function onMaintenanceModalOpenChange(open: boolean) {
+  maintenanceModalOpen.value = open
+  if (!open) {
+    status.value = pendingMaintenanceOriginalStatus.value
+  }
+}
 </script>
 
 <template>
   <div class="site-status-select">
     <ContextHolder />
+    <MaintenanceConfigModal
+      :open="maintenanceModalOpen"
+      :title="$gettext('Set maintenance information for this site')"
+      :ok-text="$gettext('Next')"
+      @update:open="onMaintenanceModalOpenChange"
+      @confirm="onMaintenanceConfirm"
+    />
     <ASelect
       :value="status"
       class="status-select"

--- a/app/src/views/site/site_list/SiteList.vue
+++ b/app/src/views/site/site_list/SiteList.vue
@@ -1,5 +1,5 @@
 <script setup lang="tsx">
-import type { Site } from '@/api/site'
+import type { MaintenancePayload, Site } from '@/api/site'
 import { StdCurd } from '@uozi-admin/curd'
 import { message, Modal } from 'antdv-next'
 import nginxLog from '@/api/nginx_log'
@@ -8,6 +8,7 @@ import FooterToolBar from '@/components/FooterToolbar'
 import InspectConfig from '@/components/InspectConfig'
 import NamespaceTabs from '@/components/NamespaceTabs'
 import { ConfigStatus } from '@/constants'
+import MaintenanceConfigModal from '@/views/site/components/MaintenanceConfigModal.vue'
 import columns from '@/views/site/site_list/columns'
 import SiteDuplicate from '@/views/site/site_list/SiteDuplicate.vue'
 
@@ -22,6 +23,8 @@ const loadingEnable = ref(false)
 const loadingDisable = ref(false)
 const loadingMaintenance = ref(false)
 const [modal, ContextHolder] = Modal.useModal()
+const maintenanceModalOpen = ref(false)
+const pendingMaintenanceNames = ref<string[]>([])
 
 const namespaceId = ref(Number.parseInt(route.query.namespace_id as string) || 0)
 
@@ -94,16 +97,16 @@ function refreshAfterBatchStatusChanged() {
 
 type BatchStatusAction = 'enable' | 'disable' | 'maintenance'
 
-function executeBatchStatusAction(action: BatchStatusAction, names: string[]) {
+function executeBatchStatusAction(action: BatchStatusAction, names: string[], payload: MaintenancePayload = {}) {
   const loadingMap = {
     enable: loadingEnable,
     disable: loadingDisable,
     maintenance: loadingMaintenance,
   }
-  const requestMap: Record<BatchStatusAction, (names: string[]) => Promise<unknown>> = {
+  const requestMap: Record<BatchStatusAction, (names: string[], payload: MaintenancePayload) => Promise<unknown>> = {
     enable: site.batchEnable,
     disable: site.batchDisable,
-    maintenance: site.batchEnableMaintenance,
+    maintenance: (maintenanceNames: string[], maintenancePayload: MaintenancePayload) => site.batchEnableMaintenance(maintenanceNames, maintenancePayload),
   }
   const successMessageMap: Record<BatchStatusAction, string> = {
     enable: $gettext('Sites enabled successfully'),
@@ -116,7 +119,7 @@ function executeBatchStatusAction(action: BatchStatusAction, names: string[]) {
   const successMessage = successMessageMap[action]
 
   loading.value = true
-  return request(names).then(() => {
+  return request(names, payload).then(() => {
     message.success(successMessage)
     refreshAfterBatchStatusChanged()
   }).finally(() => {
@@ -124,8 +127,12 @@ function executeBatchStatusAction(action: BatchStatusAction, names: string[]) {
   })
 }
 
-function confirmBatchStatusAction(action: BatchStatusAction) {
-  if (selectedSiteNames.value.length === 0) {
+function confirmBatchStatusAction(action: BatchStatusAction, payload: MaintenancePayload = {}, namesOverride?: string[]) {
+  const names = namesOverride && namesOverride.length > 0
+    ? [...namesOverride]
+    : [...selectedSiteNames.value]
+
+  if (names.length === 0) {
     const warningMessageMap: Record<BatchStatusAction, string> = {
       enable: $gettext('Please select at least one site to enable'),
       disable: $gettext('Please select at least one site to disable'),
@@ -135,7 +142,6 @@ function confirmBatchStatusAction(action: BatchStatusAction) {
     return
   }
 
-  const names = [...selectedSiteNames.value]
   const titleMap: Record<BatchStatusAction, string> = {
     enable: $gettext('Do you want to enable selected sites?'),
     disable: $gettext('Do you want to disable selected sites?'),
@@ -165,7 +171,7 @@ function confirmBatchStatusAction(action: BatchStatusAction) {
       danger: action === 'disable',
     },
     cancelText: $gettext('Cancel'),
-    onOk: () => executeBatchStatusAction(action, names),
+    onOk: () => executeBatchStatusAction(action, names, payload),
   })
 }
 
@@ -178,7 +184,25 @@ function batchDisableSites() {
 }
 
 function batchEnableMaintenanceSites() {
-  confirmBatchStatusAction('maintenance')
+  if (selectedSiteNames.value.length === 0) {
+    message.warning($gettext('Please select at least one site to switch to maintenance mode'))
+    return
+  }
+  pendingMaintenanceNames.value = [...selectedSiteNames.value]
+  maintenanceModalOpen.value = true
+}
+
+function onMaintenanceModalOpenChange(open: boolean) {
+  maintenanceModalOpen.value = open
+  if (!open) {
+    pendingMaintenanceNames.value = []
+  }
+}
+
+function onMaintenanceConfirm(payload: MaintenancePayload) {
+  const names = pendingMaintenanceNames.value.length > 0 ? pendingMaintenanceNames.value : [...selectedSiteNames.value]
+  pendingMaintenanceNames.value = []
+  confirmBatchStatusAction('maintenance', payload, names)
 }
 </script>
 
@@ -262,6 +286,13 @@ function batchEnableMaintenanceSites() {
       @duplicated="() => curd.refresh()"
     />
     <ContextHolder />
+    <MaintenanceConfigModal
+      :open="maintenanceModalOpen"
+      :title="$gettext('Set maintenance information for selected sites')"
+      :ok-text="$gettext('Next')"
+      @update:open="onMaintenanceModalOpenChange"
+      @confirm="onMaintenanceConfirm"
+    />
 
     <FooterToolBar v-if="selectedSiteNames.length > 0">
       <template #extra>

--- a/internal/site/maintenance.go
+++ b/internal/site/maintenance.go
@@ -24,6 +24,21 @@ import (
 
 const MaintenanceSuffix = "_nginx_ui_maintenance"
 
+const (
+	maintenanceSiteHeaderKey           = "X-Maintenance-Site"
+	maintenanceStartTimeHeaderKey      = "X-Maintenance-Start-Time"
+	maintenanceEndTimeHeaderKey        = "X-Maintenance-End-Time"
+	maintenanceContactHeaderKey        = "X-Maintenance-Contact"
+	maintenanceAdditionalInfoHeaderKey = "X-Maintenance-Additional-Information"
+)
+
+type MaintenancePayload struct {
+	StartTime           string `json:"start_time"`
+	EndTime             string `json:"end_time"`
+	Contact             string `json:"contact"`
+	AdditionInformation string `json:"additioninfomation"`
+}
+
 var baseMaintenanceServerDirectives = map[string]struct{}{
 	"listen":      {},
 	"server_name": {},
@@ -49,8 +64,36 @@ type maintenanceIncludeExpander struct {
 	visited map[string]struct{}
 }
 
+func sanitizeMaintenanceHeaderValue(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.ReplaceAll(value, "\r", " ")
+	value = strings.ReplaceAll(value, "\n", " ")
+	return value
+}
+
+func normalizeMaintenancePayload(payload *MaintenancePayload) MaintenancePayload {
+	if payload == nil {
+		return MaintenancePayload{}
+	}
+
+	return MaintenancePayload{
+		StartTime:           sanitizeMaintenanceHeaderValue(payload.StartTime),
+		EndTime:             sanitizeMaintenanceHeaderValue(payload.EndTime),
+		Contact:             sanitizeMaintenanceHeaderValue(payload.Contact),
+		AdditionInformation: sanitizeMaintenanceHeaderValue(payload.AdditionInformation),
+	}
+}
+
 // EnableMaintenance enables maintenance mode for a site
 func EnableMaintenance(name string) (err error) {
+	return EnableMaintenanceWithPayload(name, nil)
+}
+
+// EnableMaintenanceWithPayload enables maintenance mode for a site and injects
+// custom metadata used by maintenance pages.
+func EnableMaintenanceWithPayload(name string, payload *MaintenancePayload) (err error) {
+	normalizedPayload := normalizeMaintenancePayload(payload)
+
 	if err = validateSiteName(name); err != nil {
 		return err
 	}
@@ -88,7 +131,7 @@ func EnableMaintenance(name string) (err error) {
 	// Remote namespaces have no local Nginx to switch into maintenance mode, so
 	// the request is only dispatched to the member nodes.
 	if IsRemoteDeploy(name) {
-		go syncEnableMaintenance(name)
+		go syncEnableMaintenance(name, normalizedPayload)
 
 		return
 	}
@@ -107,7 +150,7 @@ func EnableMaintenance(name string) (err error) {
 	}
 
 	// Create new maintenance configuration
-	maintenanceConfig := createMaintenanceConfig(conf, filepath.Dir(configFilePath), name)
+	maintenanceConfig := createMaintenanceConfigWithPayload(conf, filepath.Dir(configFilePath), name, normalizedPayload)
 
 	// Write maintenance configuration to file
 	err = nginx.WriteFile(maintenanceConfigPath, []byte(maintenanceConfig), 0644)
@@ -159,7 +202,7 @@ func EnableMaintenance(name string) (err error) {
 	}
 
 	// Synchronize with other nodes
-	go syncEnableMaintenance(name)
+	go syncEnableMaintenance(name, normalizedPayload)
 
 	return nil
 }
@@ -256,6 +299,10 @@ func DisableMaintenance(name string) (err error) {
 // to the nginx configuration directory. siteName is forwarded to the maintenance page so it
 // can render a site specific template; pass "" to skip it.
 func createMaintenanceConfig(conf *config.Config, baseDir string, siteName string) string {
+	return createMaintenanceConfigWithPayload(conf, baseDir, siteName, MaintenancePayload{})
+}
+
+func createMaintenanceConfigWithPayload(conf *config.Config, baseDir string, siteName string, payload MaintenancePayload) string {
 	nginxUIPort := cSettings.ServerSettings.Port
 	schema := "http"
 	if cSettings.ServerSettings.EnableHTTPS {
@@ -314,13 +361,53 @@ func createMaintenanceConfig(conf *config.Config, baseDir string, siteName strin
 		locationContent.WriteString("proxy_set_header X-Forwarded-Proto $scheme;\n")
 		locationContent.WriteString("proxy_set_header X-Forwarded-Host $http_host;\n")
 		if siteName != "" {
-			locationContent.WriteString(fmt.Sprintf("proxy_set_header X-Maintenance-Site \"%s\";\n", escapeNginxQuotedValue(siteName)))
+			locationContent.WriteString(fmt.Sprintf("proxy_set_header %s \"%s\";\n", maintenanceSiteHeaderKey, escapeNginxQuotedValue(siteName)))
+		}
+		if payload.StartTime != "" {
+			locationContent.WriteString(fmt.Sprintf("proxy_set_header %s \"%s\";\n", maintenanceStartTimeHeaderKey, escapeNginxQuotedValue(payload.StartTime)))
+		}
+		if payload.EndTime != "" {
+			locationContent.WriteString(fmt.Sprintf("proxy_set_header %s \"%s\";\n", maintenanceEndTimeHeaderKey, escapeNginxQuotedValue(payload.EndTime)))
+		}
+		if payload.Contact != "" {
+			locationContent.WriteString(fmt.Sprintf("proxy_set_header %s \"%s\";\n", maintenanceContactHeaderKey, escapeNginxQuotedValue(payload.Contact)))
+		}
+		if payload.AdditionInformation != "" {
+			locationContent.WriteString(fmt.Sprintf("proxy_set_header %s \"%s\";\n", maintenanceAdditionalInfoHeaderKey, escapeNginxQuotedValue(payload.AdditionInformation)))
 		}
 		locationContent.WriteString("rewrite ^ /pages/maintenance break;\n")
 		locationContent.WriteString(fmt.Sprintf("proxy_pass %s://127.0.0.1:%d;\n", schema, nginxUIPort))
 
 		location.Content = locationContent.String()
 		ngxServer.Locations = append(ngxServer.Locations, location)
+
+		maintenanceMetaLocation := &nginx.NgxLocation{
+			Path: "= /pages/maintenance/meta",
+		}
+		locationContent.Reset()
+		locationContent.WriteString("proxy_set_header Host $host;\n")
+		locationContent.WriteString("proxy_set_header X-Real-IP $remote_addr;\n")
+		locationContent.WriteString("proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n")
+		locationContent.WriteString("proxy_set_header X-Forwarded-Proto $scheme;\n")
+		locationContent.WriteString("proxy_set_header X-Forwarded-Host $http_host;\n")
+		if siteName != "" {
+			locationContent.WriteString(fmt.Sprintf("proxy_set_header %s \"%s\";\n", maintenanceSiteHeaderKey, escapeNginxQuotedValue(siteName)))
+		}
+		if payload.StartTime != "" {
+			locationContent.WriteString(fmt.Sprintf("proxy_set_header %s \"%s\";\n", maintenanceStartTimeHeaderKey, escapeNginxQuotedValue(payload.StartTime)))
+		}
+		if payload.EndTime != "" {
+			locationContent.WriteString(fmt.Sprintf("proxy_set_header %s \"%s\";\n", maintenanceEndTimeHeaderKey, escapeNginxQuotedValue(payload.EndTime)))
+		}
+		if payload.Contact != "" {
+			locationContent.WriteString(fmt.Sprintf("proxy_set_header %s \"%s\";\n", maintenanceContactHeaderKey, escapeNginxQuotedValue(payload.Contact)))
+		}
+		if payload.AdditionInformation != "" {
+			locationContent.WriteString(fmt.Sprintf("proxy_set_header %s \"%s\";\n", maintenanceAdditionalInfoHeaderKey, escapeNginxQuotedValue(payload.AdditionInformation)))
+		}
+		locationContent.WriteString(fmt.Sprintf("proxy_pass %s://127.0.0.1:%d;\n", schema, nginxUIPort))
+		maintenanceMetaLocation.Content = locationContent.String()
+		ngxServer.Locations = append(ngxServer.Locations, maintenanceMetaLocation)
 
 		// Add to configuration
 		ngxConfig.Servers = append(ngxConfig.Servers, ngxServer)
@@ -669,7 +756,7 @@ func extractParams(directive config.IDirective) []string {
 }
 
 // syncEnableMaintenance synchronizes enabling maintenance mode with other nodes
-func syncEnableMaintenance(name string) {
+func syncEnableMaintenance(name string, payload MaintenancePayload) {
 	nodes := getSyncNodes(name)
 
 	wg := &sync.WaitGroup{}
@@ -689,6 +776,7 @@ func syncEnableMaintenance(name string) {
 			client := nodeauth.NewRestyClient(node)
 			client.SetBaseURL(node.URL)
 			resp, err := client.R().
+				SetBody(payload).
 				Post(fmt.Sprintf("/api/sites/%s/maintenance", name))
 			if err != nil {
 				notification.Error("Enable Remote Site Maintenance Error", err.Error(), nil)

--- a/internal/site/maintenance_test.go
+++ b/internal/site/maintenance_test.go
@@ -135,6 +135,42 @@ func TestCreateMaintenanceConfig_ForwardsSiteName(t *testing.T) {
 	}
 }
 
+func TestCreateMaintenanceConfig_WithMetadataHeadersAndEndpoint(t *testing.T) {
+	setupMaintenanceTestSettings(t, "")
+
+	p := parser.NewStringParser(`server {
+    listen 80;
+    server_name example.com;
+}`, parser.WithSkipValidDirectivesErr())
+
+	conf, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	content := createMaintenanceConfigWithPayload(conf, "", "example.com", MaintenancePayload{
+		StartTime:           "2026-09-09 10:00:00",
+		EndTime:             "2026-09-09 12:00:00",
+		Contact:             "ops@example.com",
+		AdditionInformation: "planned db migration",
+	})
+
+	expected := []string{
+		`proxy_set_header X-Maintenance-Site "example.com";`,
+		`proxy_set_header X-Maintenance-Start-Time "2026-09-09 10:00:00";`,
+		`proxy_set_header X-Maintenance-End-Time "2026-09-09 12:00:00";`,
+		`proxy_set_header X-Maintenance-Contact "ops@example.com";`,
+		`proxy_set_header X-Maintenance-Additional-Information "planned db migration";`,
+		`location = /pages/maintenance/meta {`,
+	}
+
+	for _, fragment := range expected {
+		if !strings.Contains(content, fragment) {
+			t.Fatalf("maintenance config = %q, want %q", content, fragment)
+		}
+	}
+}
+
 func TestCreateMaintenanceConfig_PreservesTLSHandshakeDirectives(t *testing.T) {
 	nginxConfigDir := t.TempDir()
 	sitesAvailableDir := filepath.Join(nginxConfigDir, "sites-available")


### PR DESCRIPTION
## Summary

This pull request enhances the site maintenance feature by adding configurable maintenance metadata.

Administrators can now configure and display:

- Maintenance start time
- Maintenance end time
- Contact information
- Additional maintenance information

The maintenance metadata is passed through Nginx request headers and displayed on the maintenance page.

## Changes

### Backend

- Introduced new maintenance metadata headers:
  - `X-Maintenance-Start-Time`
  - `X-Maintenance-End-Time`
  - `X-Maintenance-Contact`
  - `X-Maintenance-Additional-Information`
- Updated the `MaintenancePageData` structure with the new metadata fields.
- Implemented the `MaintenanceMeta` endpoint to return maintenance metadata.
- Updated site enable and maintenance-related functions to accept maintenance configuration payloads.

### Frontend

- Created the `MaintenanceConfigModal` component for configuring maintenance details.
- Enhanced the maintenance page template to display:
  - Start time
  - End time
  - Contact information
  - Additional information
- Updated language files with the new maintenance-related messages.

### Tests

- Added tests for maintenance configuration.
- Added test coverage for maintenance metadata headers.
- Verified that maintenance pages without metadata continue to use the original layout.

## Nginx Configuration Example

```nginx
location = /pages/maintenance/meta {
    proxy_set_header Host $host;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header X-Forwarded-Proto $scheme;
    proxy_set_header X-Forwarded-Host $http_host;

    proxy_set_header X-Maintenance-Site "test2";
    proxy_set_header X-Maintenance-Start-Time "2026-09-09 00:00:06";
    proxy_set_header X-Maintenance-End-Time "2026-09-09 00:00:16";
    proxy_set_header X-Maintenance-Contact "231";
    proxy_set_header X-Maintenance-Additional-Information "123321";

    proxy_pass http://127.0.0.1:9000;
}
```

## Maintenance Page Preview

### New Default Style

> # System Maintenance
>
> We are currently performing system maintenance to improve your experience.
>
> Please check back later. Thank you for your understanding and patience.
>
> **Start:** 2026-09-09 00:00:06  
> **End:** 2026-09-09 00:00:16  
> **Contact:** 231  
> **Additional:** 123321
>
> Powered by [Nginx UI](https://nginxui.com/)

### Previous Style

> # System Maintenance
>
> We are currently performing system maintenance to improve your experience.
>
> Please check back later. Thank you for your understanding and patience.
>
> Powered by [Nginx UI](https://nginxui.com/)

## Compatibility

- Existing maintenance configurations without metadata remain supported.
- Empty metadata fields are not expected to affect the existing maintenance page behavior.
- The original maintenance page content remains available when no additional maintenance details are configured.

## Testing Checklist

- [x] Configure maintenance mode without metadata
- [x] Configure maintenance mode with start and end times
- [x] Configure maintenance mode with contact information
- [x] Configure maintenance mode with additional information
- [x] Verify maintenance metadata request headers
- [x] Verify the maintenance metadata endpoint response
- [x] Verify the new maintenance page layout
- [x] Verify backward compatibility with the previous layout
- [x] Verify translated maintenance messages

## Related Issue

Closes #