### PR TITLE
fix: preserve admin status across legacy upgrades

### DIFF
--- a/docs/guide/reset-password.md
+++ b/docs/guide/reset-password.md
@@ -1,6 +1,6 @@
 # Reset Initial User Password
 
-The `reset-password` command allows you to reset the initial administrator account's password to a randomly generated 12-character password that includes uppercase letters, lowercase letters, numbers, and special symbols.
+The `reset-password` command allows you to reset the initial administrator account's password to a randomly generated 12-character password that includes uppercase letters, lowercase letters, numbers, and special symbols. It also re-enables the initial administrator account so it can recover from a disabled state.
 
 This feature was introduced in `v2.0.0-rc.4`.
 
@@ -60,4 +60,4 @@ Replace `<nginx-ui-container>` with your actual container name or ID.
 - This command is useful if you've forgotten the initial administrator password
 - The new password will be displayed in the logs, so be sure to copy it immediately
 - You must have access to the server's command line to use this feature
-- The database file must exist for this command to work 
+- The database file must exist for this command to work

--- a/internal/migrate/3.rename_auths_to_users_test.go
+++ b/internal/migrate/3.rename_auths_to_users_test.go
@@ -1,0 +1,63 @@
+package migrate
+
+import (
+	"testing"
+	"time"
+
+	"github.com/0xJacky/Nginx-UI/model"
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type beta24Auth struct {
+	ID        uint64 `gorm:"primaryKey"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt gorm.DeletedAt `gorm:"index"`
+	Name      string
+	Password  string
+}
+
+func (beta24Auth) TableName() string {
+	return "auths"
+}
+
+func TestBeta24UserIsEnabledAfterRegisteredMigrationSequence(t *testing.T) {
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, database.AutoMigrate(&beta24Auth{}))
+	require.NoError(t, database.Create(&beta24Auth{
+		ID:       1,
+		Name:     "admin",
+		Password: "legacy-hash",
+	}).Error)
+
+	runRenameAuthsMigration(t, database, BeforeAutoMigrate)
+	require.NoError(t, database.AutoMigrate(&model.User{}))
+	runRenameAuthsMigration(t, database, Migrations)
+	var migrated struct {
+		Name     string
+		Password string
+		Status   bool
+	}
+	require.NoError(t, database.Table("users").Where("id = ?", 1).Take(&migrated).Error)
+	assert.Equal(t, "admin", migrated.Name)
+	assert.Equal(t, "legacy-hash", migrated.Password)
+	assert.True(t, migrated.Status)
+}
+
+func runRenameAuthsMigration(
+	t *testing.T,
+	database *gorm.DB,
+	migrations []*gormigrate.Migration,
+) {
+	t.Helper()
+	for _, migration := range migrations {
+		if migration.ID == RenameAuthsToUsers.ID {
+			require.NoError(t, migration.Migrate(database))
+		}
+	}
+}

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -6,7 +6,6 @@ import (
 
 var Migrations = []*gormigrate.Migration{
 	SiteCategoryToNamespace,
-	RenameAuthsToUsers,
 	UpdateCertDomains,
 	RenameEnvGroupsToNamespaces,
 	RenameEnvironmentsToNodes,
@@ -17,4 +16,5 @@ var Migrations = []*gormigrate.Migration{
 
 var BeforeAutoMigrate = []*gormigrate.Migration{
 	FixSiteAndStreamPathUnique,
+	RenameAuthsToUsers,
 }

--- a/internal/user/reset_password.go
+++ b/internal/user/reset_password.go
@@ -75,10 +75,7 @@ func ResetInitUserPassword(ctx context.Context, command *cli.Command) error {
 		return err
 	}
 
-	_, err = u.Where(u.ID.Eq(1)).Updates(&model.User{
-		Password: string(pwdBytes),
-	})
-	if err != nil {
+	if err = updateInitUserPassword(string(pwdBytes)); err != nil {
 		return err
 	}
 
@@ -86,4 +83,13 @@ func ResetInitUserPassword(ctx context.Context, command *cli.Command) error {
 
 	logger.Infof("User: %s, Password: %s", user.Name, pwd)
 	return nil
+}
+
+func updateInitUserPassword(password string) error {
+	u := query.User
+	_, err := u.Where(u.ID.Eq(1)).Updates(&model.User{
+		Password: password,
+		Status:   true,
+	})
+	return err
 }

--- a/internal/user/reset_password_test.go
+++ b/internal/user/reset_password_test.go
@@ -1,0 +1,43 @@
+package user
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/0xJacky/Nginx-UI/model"
+	"github.com/0xJacky/Nginx-UI/query"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestUpdateInitUserPasswordReenablesDisabledUser(t *testing.T) {
+	dbName := fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())
+	database, err := gorm.Open(sqlite.Open(dbName), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, database.AutoMigrate(&model.User{}))
+	require.NoError(t, database.Create(&model.User{
+		Model:    model.Model{ID: 1},
+		Name:     "admin",
+		Password: "old-hash",
+		Status:   true,
+	}).Error)
+	require.NoError(t, database.Model(&model.User{}).
+		Where("id = ?", 1).Update("status", false).Error)
+	var disabled bool
+	require.NoError(t, database.Raw("SELECT status FROM users WHERE id = ?", 1).
+		Scan(&disabled).Error)
+	assert.False(t, disabled)
+
+	model.Use(database)
+	query.Use(database)
+	query.SetDefault(database)
+
+	require.NoError(t, updateInitUserPassword("new-hash"))
+
+	var updated model.User
+	require.NoError(t, database.First(&updated, 1).Error)
+	assert.Equal(t, "new-hash", updated.Password)
+	assert.True(t, updated.Status)
+}


### PR DESCRIPTION
## Problem

Upgrading directly from v2.0.0-beta.24 can leave the initial administrator disabled. That release stores the account in `auths` and has no `status` column. The rename migration currently runs after AutoMigrate, so the newly migrated user misses the enabled default. Running `reset-password` changes only the password and cannot recover the disabled account.

Fixes #1867.

## Change

- Run the `auths` to `users` rename before AutoMigrate so the current schema, including the enabled status default, is applied to the legacy row.
- Make the explicit `reset-password` recovery command re-enable user ID 1 while changing its password.
- Document the recovery behavior.

Normal startup does not re-enable intentionally disabled users. Re-enabling occurs only through the local administrator recovery command, which already requires access to the configuration and database files.

## Verification

- New tests against unchanged `dev`: migration regression fails because status is false; password recovery test does not compile because the recovery helper is absent.
- `GOWORK=off go test -tags=unembed -count=1 ./internal/migrate ./internal/user`: pass.
- `GOWORK=off go test -tags=unembed -race -cover -count=1 ./...`: pass.
- `bun install --frozen-lockfile` and `bun run docs:build`: pass.
- `git diff --check`: pass.

## Agent disclosure

Generated and reviewed by OpenAI Codex for be-student. No human review occurred before submission; maintainer review is requested.
