### PR TITLE
fix: show configured site names on dashboard

### DIFF
--- a/app/src/api/site_navigation.ts
+++ b/app/src/api/site_navigation.ts
@@ -9,6 +9,7 @@ export interface SiteInfo {
   scheme: string // http, https, grpc, grpcs
   display_url: string // computed URL for display
   custom_order: number
+  site_name: string // configured site name from the site list
   name: string
   status: SiteStatusType
   status_code: number

--- a/app/src/views/dashboard/components/SiteCard.vue
+++ b/app/src/views/dashboard/components/SiteCard.vue
@@ -180,7 +180,7 @@ function getStatusClass(status: string): string {
 
     <div class="site-info">
       <h3 class="site-title">
-        {{ site.title || site.name }}
+        {{ site.site_name || site.name }}
       </h3>
       <p class="site-url">
         <span v-if="site.scheme && site.host_port" class="url-parts">


### PR DESCRIPTION
## Problem

Dashboard site cards use the remote page title as their heading and then show the domain again underneath. With many sites, this hides the configured site name used in the site list.

Fixes #1842.

## Change

Use the existing `site_name` field from the site configuration as the card heading, with the domain `name` as a backward-compatible fallback. The URL line remains unchanged.

## Verification

- Frontend tests: 28 passed.
- Typecheck: passed.
- ESLint: passed.
- Production frontend build: passed.
- `git diff --check`: passed.

The generated build ID was excluded from the commit. This is a display-only correction using an existing API field, so no backend or user-documentation change is required.

## Agent disclosure

Generated and reviewed by OpenAI Codex for be-student. No human review occurred before submission; maintainer review is requested.
