### PR TITLE
feat: add Telegram topics and sync user context

### DIFF
--- a/api/config/add.go
+++ b/api/config/add.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/0xJacky/Nginx-UI/api"
 	"github.com/0xJacky/Nginx-UI/internal/config"
 	"github.com/0xJacky/Nginx-UI/internal/helper"
 	"github.com/0xJacky/Nginx-UI/internal/nginx"
@@ -115,7 +116,7 @@ func AddConfig(c *gin.Context) {
 		return
 	}
 
-	err = config.SyncToRemoteServer(cfg)
+	err = config.SyncToRemoteServer(cfg, api.CurrentUser(c).Name)
 	if err != nil {
 		cosy.ErrHandler(c, err)
 		return

--- a/api/config/modify.go
+++ b/api/config/modify.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/0xJacky/Nginx-UI/api"
 	"github.com/0xJacky/Nginx-UI/internal/config"
 	"github.com/0xJacky/Nginx-UI/internal/nginx"
 	"github.com/0xJacky/Nginx-UI/model"
@@ -77,7 +78,7 @@ func EditConfig(c *gin.Context) {
 	cfg.SyncNodeIds = json.SyncNodeIds
 	cfg.SyncOverwrite = json.SyncOverwrite
 
-	err = config.Save(absPath, content, cfg)
+	err = config.Save(absPath, content, cfg, api.CurrentUser(c).Name)
 	if err != nil {
 		cosy.ErrHandler(c, err)
 		return

--- a/app/src/views/preference/components/ExternalNotify/telegram.ts
+++ b/app/src/views/preference/components/ExternalNotify/telegram.ts
@@ -13,6 +13,10 @@ const TelegramConfig: ExternalNotifyConfig = {
       label: 'Chat ID',
     },
     {
+      key: 'message_thread_id',
+      label: 'Message Thread ID',
+    },
+    {
       key: 'http_proxy',
       label: 'HTTP Proxy',
     },

--- a/internal/config/save.go
+++ b/internal/config/save.go
@@ -11,7 +11,7 @@ import (
 	"gorm.io/gen/field"
 )
 
-func Save(absPath string, content string, cfg *model.Config) (err error) {
+func Save(absPath string, content string, cfg *model.Config, userNames ...string) (err error) {
 	q := query.Config
 	if cfg == nil {
 		cfg, err = q.Assign(field.Attrs(&model.Config{
@@ -54,7 +54,11 @@ func Save(absPath string, content string, cfg *model.Config) (err error) {
 		return
 	}
 
-	err = SyncToRemoteServer(cfg)
+	userName := ""
+	if len(userNames) > 0 {
+		userName = userNames[0]
+	}
+	err = SyncToRemoteServer(cfg, userName)
 	if err != nil {
 		return
 	}

--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -25,7 +25,7 @@ type SyncConfigPayload struct {
 	Overwrite bool   `json:"overwrite"`
 }
 
-func SyncToRemoteServer(c *model.Config) (err error) {
+func SyncToRemoteServer(c *model.Config, userName string) (err error) {
 	if c == nil || c.Filepath == "" {
 		return
 	}
@@ -62,7 +62,7 @@ func SyncToRemoteServer(c *model.Config) (err error) {
 	nodes, _ := q.Where(q.ID.In(syncNodeIds...), q.Enabled.Is(true)).Find()
 	for _, node := range nodes {
 		go func() {
-			err := payload.deploy(node, c, payloadBytes)
+			err := payload.deploy(node, c, payloadBytes, userName)
 			if err != nil {
 				logger.Error(err)
 			}
@@ -109,10 +109,11 @@ type SyncNotificationPayload struct {
 	StatusCode int    `json:"status_code"`
 	ConfigName string `json:"config_name"`
 	NodeName   string `json:"node_name"`
+	UserName   string `json:"user_name,omitempty"`
 	Response   string `json:"response"`
 }
 
-func (p *SyncConfigPayload) deploy(node *model.Node, c *model.Config, payloadBytes []byte) (err error) {
+func (p *SyncConfigPayload) deploy(node *model.Node, c *model.Config, payloadBytes []byte, userName string) (err error) {
 	client, err := nodeauth.NewHTTPClient(node, 0)
 	if err != nil {
 		return
@@ -140,17 +141,31 @@ func (p *SyncConfigPayload) deploy(node *model.Node, c *model.Config, payloadByt
 		StatusCode: resp.StatusCode,
 		ConfigName: c.Name,
 		NodeName:   node.Name,
+		UserName:   userName,
 		Response:   string(respBody),
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		notification.Error("Sync Config Error", "Sync config %{config_name} to %{node_name} failed", notificationPayload)
+		notification.Error("Sync Config Error", syncConfigNotificationContent(userName, false), notificationPayload)
 		return
 	}
 
-	notification.Success("Sync Config Success", "Sync config %{config_name} to %{node_name} successfully", notificationPayload)
+	notification.Success("Sync Config Success", syncConfigNotificationContent(userName, true), notificationPayload)
 
 	return
+}
+
+func syncConfigNotificationContent(userName string, success bool) string {
+	if userName == "" {
+		if success {
+			return "Sync config %{config_name} to %{node_name} successfully"
+		}
+		return "Sync config %{config_name} to %{node_name} failed"
+	}
+	if success {
+		return "User %{user_name} synced config %{config_name} to %{node_name} successfully"
+	}
+	return "User %{user_name} failed to sync config %{config_name} to %{node_name}"
 }
 
 type RenameConfigPayload struct {

--- a/internal/config/sync_notification_test.go
+++ b/internal/config/sync_notification_test.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSyncConfigNotificationContentIncludesActingUser(t *testing.T) {
+	for _, success := range []bool{true, false} {
+		content := syncConfigNotificationContent("alice", success)
+		if !strings.Contains(content, "%{user_name}") {
+			t.Fatalf("content = %q", content)
+		}
+	}
+}
+
+func TestSyncConfigNotificationContentKeepsLegacyMessageWithoutUser(t *testing.T) {
+	if got := syncConfigNotificationContent("", true); got != "Sync config %{config_name} to %{node_name} successfully" {
+		t.Fatalf("success content = %q", got)
+	}
+	if got := syncConfigNotificationContent("", false); got != "Sync config %{config_name} to %{node_name} failed" {
+		t.Fatalf("failure content = %q", got)
+	}
+}

--- a/internal/config/sync_notification_test.go
+++ b/internal/config/sync_notification_test.go
@@ -3,6 +3,9 @@ package config
 import (
 	"strings"
 	"testing"
+
+	"github.com/0xJacky/Nginx-UI/internal/notification"
+	"github.com/0xJacky/Nginx-UI/model"
 )
 
 func TestSyncConfigNotificationContentIncludesActingUser(t *testing.T) {
@@ -20,5 +23,22 @@ func TestSyncConfigNotificationContentKeepsLegacyMessageWithoutUser(t *testing.T
 	}
 	if got := syncConfigNotificationContent("", false); got != "Sync config %{config_name} to %{node_name} failed" {
 		t.Fatalf("failure content = %q", got)
+	}
+}
+
+func TestSyncConfigNotificationRendersActingUser(t *testing.T) {
+	message := &notification.ExternalMessage{Notification: &model.Notification{
+		Content: syncConfigNotificationContent("alice", true),
+		Details: &SyncNotificationPayload{
+			ConfigName: "nginx.conf",
+			NodeName:   "edge-1",
+			UserName:   "alice",
+		},
+	}}
+
+	got := message.GetContent("en")
+	want := "User alice synced config nginx.conf to edge-1 successfully"
+	if got != want {
+		t.Fatalf("GetContent() = %q, want %q", got, want)
 	}
 }

--- a/internal/notification/telegram.go
+++ b/internal/notification/telegram.go
@@ -9,16 +9,18 @@ import (
 
 	"github.com/0xJacky/Nginx-UI/model"
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
-	"github.com/nikoksr/notify/service/telegram"
 	"github.com/uozi-tech/cosy/map2struct"
 )
 
 // @external_notifier(Telegram)
 type Telegram struct {
-	BotToken  string `json:"bot_token" title:"Bot Token"`
-	ChatID    string `json:"chat_id" title:"Chat ID"`
-	HTTPProxy string `json:"http_proxy" title:"HTTP Proxy"`
+	BotToken        string `json:"bot_token" title:"Bot Token"`
+	ChatID          string `json:"chat_id" title:"Chat ID"`
+	MessageThreadID string `json:"message_thread_id" title:"Message Thread ID"`
+	HTTPProxy       string `json:"http_proxy" title:"HTTP Proxy"`
 }
+
+var newTelegramBotAPI = tgbotapi.NewBotAPIWithClient
 
 func init() {
 	RegisterExternalNotifier("telegram", func(ctx context.Context, n *model.ExternalNotify, msg *ExternalMessage) error {
@@ -40,18 +42,6 @@ func init() {
 			client = &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
 		}
 
-		botAPI, err := tgbotapi.NewBotAPIWithClient(telegramConfig.BotToken, client)
-		if err != nil {
-			return err
-		}
-
-		telegramService, err := telegram.New(telegramConfig.BotToken)
-		if err != nil {
-			return err
-		}
-
-		telegramService.SetClient(botAPI)
-
 		// ChatID must be an integer for telegram service
 		chatIDInt, err := strconv.ParseInt(telegramConfig.ChatID, 10, 64)
 		if err != nil {
@@ -63,8 +53,42 @@ func init() {
 			return ErrTelegramChatIDZero
 		}
 
-		telegramService.AddReceivers(chatIDInt)
+		var messageThreadID int64
+		if telegramConfig.MessageThreadID != "" {
+			messageThreadID, err = strconv.ParseInt(
+				telegramConfig.MessageThreadID, 10, 64,
+			)
+			if err != nil || messageThreadID <= 0 {
+				return fmt.Errorf(
+					"invalid Telegram Message Thread ID %q",
+					telegramConfig.MessageThreadID,
+				)
+			}
+		}
 
-		return telegramService.Send(ctx, msg.GetTitle(n.Language), msg.GetContent(n.Language))
+		botAPI, err := newTelegramBotAPI(telegramConfig.BotToken, client)
+		if err != nil {
+			return err
+		}
+
+		params := url.Values{
+			"chat_id":    {strconv.FormatInt(chatIDInt, 10)},
+			"text":       {msg.GetTitle(n.Language) + "\n" + msg.GetContent(n.Language)},
+			"parse_mode": {tgbotapi.ModeHTML},
+		}
+		if messageThreadID > 0 {
+			params.Set("message_thread_id", strconv.FormatInt(messageThreadID, 10))
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			_, err = botAPI.MakeRequest("sendMessage", params)
+			if err != nil {
+				return fmt.Errorf("send message to chat %d: %w", chatIDInt, err)
+			}
+			return nil
+		}
 	})
 }

--- a/internal/notification/telegram_test.go
+++ b/internal/notification/telegram_test.go
@@ -1,0 +1,84 @@
+package notification
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/0xJacky/Nginx-UI/model"
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+)
+
+type telegramRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f telegramRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func TestTelegramNotifierSendsMessageToConfiguredTopic(t *testing.T) {
+	originalFactory := newTelegramBotAPI
+	t.Cleanup(func() { newTelegramBotAPI = originalFactory })
+
+	var sentForm url.Values
+	newTelegramBotAPI = func(token string, _ *http.Client) (*tgbotapi.BotAPI, error) {
+		return &tgbotapi.BotAPI{
+			Token: token,
+			Client: &http.Client{Transport: telegramRoundTripFunc(
+				func(request *http.Request) (*http.Response, error) {
+					if err := request.ParseForm(); err != nil {
+						t.Fatalf("ParseForm() error = %v", err)
+					}
+					sentForm = request.PostForm
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(
+							`{"ok":true,"result":{}}`,
+						)),
+						Header: make(http.Header),
+					}, nil
+				},
+			)},
+		}, nil
+	}
+
+	message := &ExternalMessage{Notification: &model.Notification{
+		Title:   "Sync Config Success",
+		Content: "Configuration synchronized",
+	}}
+	err := message.SendWithConfigContext(context.Background(), "telegram", "en", map[string]string{
+		"bot_token":         "test-token",
+		"chat_id":           "-1001234567890",
+		"message_thread_id": "42",
+	})
+	if err != nil {
+		t.Fatalf("SendWithConfigContext() error = %v", err)
+	}
+
+	if got := sentForm.Get("chat_id"); got != "-1001234567890" {
+		t.Fatalf("chat_id = %q", got)
+	}
+	if got := sentForm.Get("message_thread_id"); got != "42" {
+		t.Fatalf("message_thread_id = %q", got)
+	}
+	if got := sentForm.Get("parse_mode"); got != tgbotapi.ModeHTML {
+		t.Fatalf("parse_mode = %q", got)
+	}
+	if got := sentForm.Get("text"); got != "Sync Config Success\nConfiguration synchronized" {
+		t.Fatalf("text = %q", got)
+	}
+}
+
+func TestTelegramNotifierRejectsInvalidMessageThreadID(t *testing.T) {
+	message := &ExternalMessage{Notification: &model.Notification{}}
+	err := message.SendWithConfig("telegram", "en", map[string]string{
+		"bot_token":         "test-token",
+		"chat_id":           "-1001234567890",
+		"message_thread_id": "not-a-number",
+	})
+	if err == nil || !strings.Contains(err.Error(), "Message Thread ID") {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/mcp/config/config_add.go
+++ b/mcp/config/config_add.go
@@ -115,7 +115,7 @@ func handleNginxConfigAdd(ctx context.Context, request mcpgo.CallToolRequest) (*
 		return nil, err
 	}
 
-	err = config.SyncToRemoteServer(cfg)
+	err = config.SyncToRemoteServer(cfg, "")
 	if err != nil {
 		return nil, err
 	}

--- a/mcp/config/config_modify.go
+++ b/mcp/config/config_modify.go
@@ -89,7 +89,7 @@ func handleNginxConfigModify(ctx context.Context, request mcpgo.CallToolRequest)
 	cfg.SyncNodeIds = syncNodeIds
 	cfg.SyncOverwrite = syncOverwrite
 
-	err = config.Save(absPath, content, cfg)
+	err = config.Save(absPath, content, cfg, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #1352.

This adds the optional Telegram `message_thread_id` setting to the generated External Notify form and sends it through the Bot API `sendMessage` request, so notifications can target a forum topic. Invalid or non-positive thread IDs are rejected before any network request.

Config file synchronization initiated through the interactive add and edit APIs now carries the acting user's name into success and failure notifications. MCP and internal callers have no interactive user, so they retain the existing message text.

Validation:

- `GOWORK=off go test -tags=unembed -race -count=1 ./internal/notification ./internal/config ./api/config ./mcp/config`
- `GOWORK=off go test -tags=unembed -race -cover -count=1 ./...`
- `bun test`: 28 passed
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- The external-notifier generator was run in an isolated copy and reproduced the committed Telegram TypeScript configuration byte-for-byte.

## Agent Disclosure

This PR was generated by OpenAI Codex. The submitting account is operated by be-student (eunwoo song).
Human review of this PR: no — fully automated. Maintainer review is requested.
