### PR TITLE
fix(site): restore previous status after canceling status change

### DIFF
--- a/app/src/views/site/components/SiteStatusSelect.vue
+++ b/app/src/views/site/components/SiteStatusSelect.vue
@@ -8,6 +8,7 @@ import { ConfigStatus } from '@/constants'
 // Define props with TypeScript
 const props = defineProps<{
   siteName: string
+  status: SiteStatus
 }>()
 
 // Define event for status change notification
@@ -15,10 +16,18 @@ const emit = defineEmits<{
   statusChanged: [{ status: SiteStatus }]
 }>()
 
-// Use defineModel for v-model binding
-const status = defineModel<string>({
-  default: ConfigStatus.Disabled,
-})
+const displayStatus = ref<SiteStatus>(props.status)
+const selectRenderKey = ref(0)
+
+watch(() => props.status, val => {
+  displayStatus.value = val
+  selectRenderKey.value += 1
+}, { immediate: true })
+
+function restoreDisplayStatus(statusValue: SiteStatus) {
+  displayStatus.value = statusValue
+  selectRenderKey.value += 1
+}
 
 const { message } = useGlobalApp()
 const [modal, ContextHolder] = Modal.useModal()
@@ -60,14 +69,14 @@ const selectStyle = computed(() => {
       'color': '#ffffff',
     },
   }
-  return statusStyles[status.value] || {}
+  return statusStyles[displayStatus.value] || {}
 })
 
 // Enable the site
 function enable() {
   site.enable(props.siteName).then(() => {
     message.success($gettext('Enabled successfully'))
-    status.value = ConfigStatus.Enabled
+    restoreDisplayStatus(ConfigStatus.Enabled)
     emit('statusChanged', {
       status: ConfigStatus.Enabled,
     })
@@ -80,7 +89,7 @@ function enable() {
 function disable() {
   site.disable(props.siteName).then(() => {
     message.success($gettext('Disabled successfully'))
-    status.value = ConfigStatus.Disabled
+    restoreDisplayStatus(ConfigStatus.Disabled)
     emit('statusChanged', {
       status: ConfigStatus.Disabled,
     })
@@ -93,7 +102,7 @@ function disable() {
 function enableMaintenance() {
   site.enableMaintenance(props.siteName).then(() => {
     message.success($gettext('Maintenance mode enabled successfully'))
-    status.value = ConfigStatus.Maintenance
+    restoreDisplayStatus(ConfigStatus.Maintenance)
     emit('statusChanged', {
       status: ConfigStatus.Maintenance,
     })
@@ -106,7 +115,7 @@ function enableMaintenance() {
 function disableMaintenance() {
   site.enable(props.siteName).then(() => {
     message.success($gettext('Maintenance mode disabled successfully'))
-    status.value = ConfigStatus.Enabled
+    restoreDisplayStatus(ConfigStatus.Enabled)
     emit('statusChanged', {
       status: ConfigStatus.Enabled,
     })
@@ -117,13 +126,14 @@ function disableMaintenance() {
 
 // Handle status change from select
 function onChangeStatus(value: SelectValue) {
-  const statusValue = value as string
-  if (!statusValue || statusValue === status.value) {
+  const statusValue = value as SiteStatus
+  if (!statusValue || statusValue === displayStatus.value) {
     return
   }
 
-  // Save original status to restore if user cancels
-  const originalStatus = status.value
+  // Keep displaying original status until user confirms and backend succeeds.
+  const originalStatus = displayStatus.value
+  restoreDisplayStatus(originalStatus)
 
   const statusMap = {
     [ConfigStatus.Enabled]: $gettext('enable'),
@@ -139,7 +149,7 @@ function onChangeStatus(value: SelectValue) {
     cancelText: $gettext('Cancel'),
     async onOk() {
       if (statusValue === ConfigStatus.Enabled) {
-        if (status.value === ConfigStatus.Maintenance) {
+        if (displayStatus.value === ConfigStatus.Maintenance) {
           disableMaintenance()
         }
         else {
@@ -155,9 +165,30 @@ function onChangeStatus(value: SelectValue) {
     },
     onCancel() {
       // Restore original status if user cancels
-      status.value = originalStatus
+      restoreDisplayStatus(originalStatus)
     },
   })
+}
+
+function onMaintenanceConfirm(payload: MaintenancePayload) {
+  modal.confirm({
+    title: $gettext('Do you want to set this site to maintenance mode?'),
+    mask: false,
+    centered: true,
+    okText: $gettext('Maintenance'),
+    cancelText: $gettext('Cancel'),
+    onOk: () => enableMaintenance(payload),
+    onCancel: () => {
+      restoreDisplayStatus(pendingMaintenanceOriginalStatus.value as SiteStatus)
+    },
+  })
+}
+
+function onMaintenanceModalOpenChange(open: boolean) {
+  maintenanceModalOpen.value = open
+  if (!open) {
+    restoreDisplayStatus(pendingMaintenanceOriginalStatus.value as SiteStatus)
+  }
 }
 </script>
 
@@ -165,7 +196,8 @@ function onChangeStatus(value: SelectValue) {
   <div class="site-status-select">
     <ContextHolder />
     <ASelect
-      :value="status"
+      :key="selectRenderKey"
+      :value="displayStatus"
       class="status-select"
       :popup-match-select-width="false"
       :styles="{

--- a/app/src/views/site/site_list/columns.tsx
+++ b/app/src/views/site/site_list/columns.tsx
@@ -122,13 +122,9 @@ const columns: StdTableColumn[] = [{
   customRender: (args: CustomRenderArgs<Site>) => {
     const { text, record } = args
     return h(SiteStatusSelect, {
-      'modelValue': text,
+      'status': text as SiteStatus,
       'siteName': record.name,
       'enabled': record.status !== ConfigStatus.Disabled,
-      'onUpdate:modelValue': (val: string) => {
-        // This will be handled by the component internal events
-        record.status = val as SiteStatus
-      },
       'onStatusChanged': ({ status }: { status: SiteStatus }) => {
         record.status = status
       },


### PR DESCRIPTION
## Summary

Fix the inconsistent site status displayed in the dropdown after canceling a status change.

## Problem

After selecting a site status, canceling the confirmation dialog still caused the dropdown to display the newly selected status, even though the actual site status was not changed.

## Solution

- Restore the original site status when the operation is canceled.
- Only update the displayed status after the status change succeeds.
- Keep the dropdown state consistent with the actual site status.

## Test Cases

- [x] Confirming a status change updates both the dropdown and the actual site status.
- [x] Canceling a status change restores the original dropdown value.
- [x] Canceling a status change does not modify the actual site status.
- [x] The displayed status remains consistent with the backend state.

## Related Issue

Fixes #