### PR TITLE
Fix(site list) status select cancle display issue

### DIFF
--- a/app/src/views/site/components/SiteStatusSelect.vue
+++ b/app/src/views/site/components/SiteStatusSelect.vue
@@ -9,6 +9,7 @@ import MaintenanceConfigModal from '@/views/site/components/MaintenanceConfigMod
 // Define props with TypeScript
 const props = defineProps<{
   siteName: string
+  status: SiteStatus
 }>()
 
 // Define event for status change notification
@@ -16,15 +17,22 @@ const emit = defineEmits<{
   statusChanged: [{ status: SiteStatus }]
 }>()
 
-// Use defineModel for v-model binding
-const status = defineModel<string>({
-  default: ConfigStatus.Disabled,
-})
-
 const { message } = useGlobalApp()
 const [modal, ContextHolder] = Modal.useModal()
 const maintenanceModalOpen = ref(false)
-const pendingMaintenanceOriginalStatus = ref<string>(ConfigStatus.Disabled)
+const pendingMaintenanceOriginalStatus = ref<SiteStatus>(ConfigStatus.Disabled)
+const displayStatus = ref<SiteStatus>(props.status)
+const selectRenderKey = ref(0)
+
+watch(() => props.status, val => {
+  displayStatus.value = val
+  selectRenderKey.value += 1
+}, { immediate: true })
+
+function restoreDisplayStatus(statusValue: SiteStatus) {
+  displayStatus.value = statusValue
+  selectRenderKey.value += 1
+}
 
 const statusOptions = computed<SelectProps['options']>(() => [
   {
@@ -63,14 +71,14 @@ const selectStyle = computed(() => {
       'color': '#ffffff',
     },
   }
-  return statusStyles[status.value] || {}
+  return statusStyles[displayStatus.value] || {}
 })
 
 // Enable the site
 function enable() {
   site.enable(props.siteName).then(() => {
     message.success($gettext('Enabled successfully'))
-    status.value = ConfigStatus.Enabled
+    restoreDisplayStatus(ConfigStatus.Enabled)
     emit('statusChanged', {
       status: ConfigStatus.Enabled,
     })
@@ -83,7 +91,7 @@ function enable() {
 function disable() {
   site.disable(props.siteName).then(() => {
     message.success($gettext('Disabled successfully'))
-    status.value = ConfigStatus.Disabled
+    restoreDisplayStatus(ConfigStatus.Disabled)
     emit('statusChanged', {
       status: ConfigStatus.Disabled,
     })
@@ -96,7 +104,7 @@ function disable() {
 function enableMaintenance(payload: MaintenancePayload) {
   site.enableMaintenance(props.siteName, payload).then(() => {
     message.success($gettext('Maintenance mode enabled successfully'))
-    status.value = ConfigStatus.Maintenance
+    restoreDisplayStatus(ConfigStatus.Maintenance)
     emit('statusChanged', {
       status: ConfigStatus.Maintenance,
     })
@@ -109,7 +117,7 @@ function enableMaintenance(payload: MaintenancePayload) {
 function disableMaintenance() {
   site.enable(props.siteName).then(() => {
     message.success($gettext('Maintenance mode disabled successfully'))
-    status.value = ConfigStatus.Enabled
+    restoreDisplayStatus(ConfigStatus.Enabled)
     emit('statusChanged', {
       status: ConfigStatus.Enabled,
     })
@@ -120,13 +128,13 @@ function disableMaintenance() {
 
 // Handle status change from select
 function onChangeStatus(value: SelectValue) {
-  const statusValue = value as string
-  if (!statusValue || statusValue === status.value) {
+  const statusValue = value as SiteStatus
+  if (!statusValue || statusValue === displayStatus.value) {
     return
   }
 
-  // Save original status to restore if user cancels
-  const originalStatus = status.value
+  const originalStatus = displayStatus.value
+  restoreDisplayStatus(originalStatus)
 
   if (statusValue === ConfigStatus.Maintenance) {
     pendingMaintenanceOriginalStatus.value = originalStatus
@@ -148,7 +156,7 @@ function onChangeStatus(value: SelectValue) {
     cancelText: $gettext('Cancel'),
     async onOk() {
       if (statusValue === ConfigStatus.Enabled) {
-        if (status.value === ConfigStatus.Maintenance) {
+        if (displayStatus.value === ConfigStatus.Maintenance) {
           disableMaintenance()
         }
         else {
@@ -160,8 +168,7 @@ function onChangeStatus(value: SelectValue) {
       }
     },
     onCancel() {
-      // Restore original status if user cancels
-      status.value = originalStatus
+      restoreDisplayStatus(originalStatus)
     },
   })
 }
@@ -174,16 +181,14 @@ function onMaintenanceConfirm(payload: MaintenancePayload) {
     okText: $gettext('Maintenance'),
     cancelText: $gettext('Cancel'),
     onOk: () => enableMaintenance(payload),
-    onCancel: () => {
-      status.value = pendingMaintenanceOriginalStatus.value
-    },
+    onCancel: () => restoreDisplayStatus(pendingMaintenanceOriginalStatus.value),
   })
 }
 
 function onMaintenanceModalOpenChange(open: boolean) {
   maintenanceModalOpen.value = open
   if (!open) {
-    status.value = pendingMaintenanceOriginalStatus.value
+    restoreDisplayStatus(pendingMaintenanceOriginalStatus.value)
   }
 }
 </script>
@@ -199,7 +204,8 @@ function onMaintenanceModalOpenChange(open: boolean) {
       @confirm="onMaintenanceConfirm"
     />
     <ASelect
-      :value="status"
+      :key="selectRenderKey"
+      :value="displayStatus"
       class="status-select"
       :popup-match-select-width="false"
       :styles="{

--- a/app/src/views/site/site_edit/components/RightPanel/Basic.vue
+++ b/app/src/views/site/site_edit/components/RightPanel/Basic.vue
@@ -28,7 +28,7 @@ function handleStatusChanged(event: { status: SiteStatus }) {
       <AForm layout="vertical">
         <AFormItem :label="$gettext('Status')">
           <SiteStatusSelect
-            v-model="data.status"
+            :status="data.status"
             :site-name="name"
             @status-changed="handleStatusChanged"
           />

--- a/app/src/views/site/site_list/columns.tsx
+++ b/app/src/views/site/site_list/columns.tsx
@@ -122,14 +122,9 @@ const columns: StdTableColumn[] = [{
   customRender: (args: CustomRenderArgs<Site>) => {
     const { text, record } = args
     return h(SiteStatusSelect, {
-      'modelValue': text,
-      'siteName': record.name,
-      'enabled': record.status !== ConfigStatus.Disabled,
-      'onUpdate:modelValue': (val: string) => {
-        // This will be handled by the component internal events
-        record.status = val as SiteStatus
-      },
-      'onStatusChanged': ({ status }: { status: SiteStatus }) => {
+      status: text as SiteStatus,
+      siteName: record.name,
+      onStatusChanged: ({ status }: { status: SiteStatus }) => {
         record.status = status
       },
     })


### PR DESCRIPTION
## Issue

In the Site List page, when a user selects a different site status and then clicks **Cancel** in the confirmation dialog, the displayed status and its corresponding color may become inconsistent with the actual site status.

## Root Cause

The status selection component updates the displayed value and style based on different state sources. When the confirmation dialog is canceled, the displayed status is not fully restored, resulting in inconsistent text and color.

## Solution

- Added status restoration logic when users cancel status changes.
- Synchronized status display and color rendering.
- Forced Select component refresh after status rollback.


## Result

After canceling any status change operation, both the displayed status and color are correctly restored to the original value, ensuring a consistent UI.

<img width="1412" height="163" alt="image" src="https://github.com/user-attachments/assets/d112867a-160f-4ff5-ae7f-02fd57102302" />
