### PR TITLE
feat: allow a custom maintenance host

### DIFF
--- a/app/src/api/settings.ts
+++ b/app/src/api/settings.ts
@@ -87,6 +87,7 @@ export interface NginxSettings {
   container_name: string
   maintenance_dir?: string
   maintenance_template?: string
+  maintenance_host?: string
   host_mode?: string
 
   // Host-via-SSH mode fields

--- a/app/src/views/preference/tabs/NginxSettings.vue
+++ b/app/src/views/preference/tabs/NginxSettings.vue
@@ -169,6 +169,15 @@ async function openSSHSetup() {
     <AFormItem :label="$gettext('Stub Status Port')">
       <AInputNumber v-model:value="data.nginx.stub_status_port" />
     </AFormItem>
+    <AFormItem :label="$gettext('Maintenance host')">
+      <AInput
+        v-model:value="data.nginx.maintenance_host"
+        :placeholder="$gettext('http://127.0.0.1:9000')"
+      />
+      <div class="text-secondary mt-1">
+        {{ $gettext('Optional HTTP or HTTPS origin that serves the maintenance page. Leave empty to use this Nginx UI instance.') }}
+      </div>
+    </AFormItem>
     <AFormItem :label="$gettext('Maintenance template (filename only)')">
       <AInput
         v-model:value="data.nginx.maintenance_template"

--- a/internal/site/maintenance.go
+++ b/internal/site/maintenance.go
@@ -308,6 +308,7 @@ func createMaintenanceConfigWithPayload(conf *config.Config, baseDir string, sit
 	if cSettings.ServerSettings.EnableHTTPS {
 		schema = "https"
 	}
+	maintenanceHost := settings.NginxSettings.GetMaintenanceHost(schema, nginxUIPort)
 
 	// Create new configuration
 	ngxConfig := nginx.NewNgxConfig("")
@@ -376,7 +377,7 @@ func createMaintenanceConfigWithPayload(conf *config.Config, baseDir string, sit
 			locationContent.WriteString(fmt.Sprintf("proxy_set_header %s \"%s\";\n", maintenanceAdditionalInfoHeaderKey, escapeNginxQuotedValue(payload.AdditionInformation)))
 		}
 		locationContent.WriteString("rewrite ^ /pages/maintenance break;\n")
-		locationContent.WriteString(fmt.Sprintf("proxy_pass %s://127.0.0.1:%d;\n", schema, nginxUIPort))
+		locationContent.WriteString(fmt.Sprintf("proxy_pass %s;\n", maintenanceHost))
 
 		location.Content = locationContent.String()
 		ngxServer.Locations = append(ngxServer.Locations, location)

--- a/internal/site/maintenance_test.go
+++ b/internal/site/maintenance_test.go
@@ -65,6 +65,27 @@ func TestCreateMaintenanceConfig_PreservesForwardedHost(t *testing.T) {
 	}
 }
 
+func TestCreateMaintenanceConfig_UsesConfiguredMaintenanceHost(t *testing.T) {
+	setupMaintenanceTestSettings(t, "")
+	originalHost := settings.NginxSettings.MaintenanceHost
+	t.Cleanup(func() { settings.NginxSettings.MaintenanceHost = originalHost })
+	settings.NginxSettings.MaintenanceHost = "https://maintenance.internal:9443"
+
+	p := parser.NewStringParser(`server {
+    listen 443 ssl;
+    server_name example.com;
+}`, parser.WithSkipValidDirectivesErr())
+	conf, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	content := createMaintenanceConfig(conf, "", "example.com")
+	if !strings.Contains(content, "proxy_pass https://maintenance.internal:9443;") {
+		t.Fatalf("maintenance config = %q, want configured maintenance host", content)
+	}
+}
+
 // TestDisableMaintenanceRestoresMaintenanceConfigWhenReloadFails guards against
 // leaving a site with neither the normal nor the maintenance config enabled:
 // when Nginx accepts the new config on `-t` but fails to reload it, the site

--- a/settings/nginx.go
+++ b/settings/nginx.go
@@ -1,5 +1,11 @@
 package settings
 
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
 const (
 	ControlModeLocal             = "local"
 	ControlModeExternalContainer = "external_container"
@@ -47,6 +53,7 @@ type Nginx struct {
 	ContainerName       string   `json:"container_name" protected:"true"`
 	MaintenanceDir      string   `json:"maintenance_dir" protected:"true"`
 	MaintenanceTemplate string   `json:"maintenance_template"`
+	MaintenanceHost     string   `json:"maintenance_host"`
 
 	// Host SSH mode fields enable nginx-ui (running in Docker) to control
 	// nginx installed natively on the same host via an SSH tunnel.
@@ -81,6 +88,26 @@ func (n *Nginx) GetMaintenanceDir() string {
 		return DefaultMaintenanceDir
 	}
 	return n.MaintenanceDir
+}
+
+// GetMaintenanceHost returns the upstream used by generated maintenance
+// configurations. Invalid values fall back to the local Nginx UI listener so
+// persisted configuration can never inject arbitrary Nginx directives.
+func (n *Nginx) GetMaintenanceHost(defaultScheme string, defaultPort uint) string {
+	fallback := fmt.Sprintf("%s://127.0.0.1:%d", defaultScheme, defaultPort)
+	raw := strings.TrimSpace(n.MaintenanceHost)
+	if raw == "" {
+		return fallback
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") ||
+		parsed.Host == "" || parsed.User != nil ||
+		(parsed.Path != "" && parsed.Path != "/") || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return fallback
+	}
+
+	return parsed.Scheme + "://" + parsed.Host
 }
 
 func (n *Nginx) GetHostKnownHostsPath() string {

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -207,3 +207,28 @@ func TestSetup(t *testing.T) {
 
 	os.Clearenv()
 }
+
+func TestGetMaintenanceHost(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "default", want: "http://127.0.0.1:9000"},
+		{name: "custom host", value: "https://maintenance.internal:9443", want: "https://maintenance.internal:9443"},
+		{name: "trailing slash", value: "http://maintenance.internal/", want: "http://maintenance.internal"},
+		{name: "directive injection", value: "http://host; return 200", want: "http://127.0.0.1:9000"},
+		{name: "path", value: "https://maintenance.internal/page", want: "http://127.0.0.1:9000"},
+		{name: "credentials", value: "https://user:pass@maintenance.internal", want: "http://127.0.0.1:9000"},
+		{name: "unsupported scheme", value: "file:///tmp/page", want: "http://127.0.0.1:9000"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			nginxSettings := &Nginx{MaintenanceHost: test.value}
+			if got := nginxSettings.GetMaintenanceHost("http", 9000); got != test.want {
+				t.Fatalf("GetMaintenanceHost() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add an optional maintenance host setting
- route generated maintenance configurations to that HTTP or HTTPS origin
- reject paths, credentials, unsupported schemes, and malformed values by falling back to the local Nginx UI listener
- expose the setting in Preferences with frontend typing and guidance

Closes #1068.

## Validation

- `GOWORK=off go test -tags=unembed -race -cover -count=1 ./...`
- `bun run typecheck`
- `bun run lint`
- `bun test` (28 passed)
- `bun run build`

## AI assistance

This change was implemented and locally verified with Codex assistance. No human review is claimed.
