### PR TITLE
feat: add site descriptions

### DIFF
--- a/api/sites/site.go
+++ b/api/sites/site.go
@@ -258,6 +258,7 @@ func SaveSite(c *gin.Context) {
 		DNSRecordName *string                `json:"dns_record_name"`
 		DNSRecordType *string                `json:"dns_record_type"`
 		DNSRecords    *[]model.SiteDNSRecord `json:"dns_records"`
+		Description   string                 `json:"description" binding:"max=500"`
 	}
 
 	if !cosy.BindAndValid(c, &json) {
@@ -289,6 +290,7 @@ func SaveSite(c *gin.Context) {
 	if err != nil {
 		logger.Warn("Failed to find or create site for DNS update:", err)
 	} else {
+		siteModel.Description = strings.TrimSpace(json.Description)
 		var linkedRecords []model.SiteDNSRecord
 		if json.DNSRecords != nil {
 			linkedRecords = normalizeDNSRecords(*json.DNSRecords)

--- a/app/src/api/site.ts
+++ b/app/src/api/site.ts
@@ -25,6 +25,7 @@ export interface Site extends ModelBase {
   path: string
   advanced: boolean
   name: string
+  description?: string
   filepath: string
   config: string
   auto_cert: boolean

--- a/app/src/views/site/site_edit/components/RightPanel/Basic.vue
+++ b/app/src/views/site/site_edit/components/RightPanel/Basic.vue
@@ -36,6 +36,14 @@ function handleStatusChanged(event: { status: SiteStatus }) {
         <AFormItem :label="$gettext('Name')">
           <ConfigName v-if="name" :name />
         </AFormItem>
+        <AFormItem :label="$gettext('Description')">
+          <ATextarea
+            v-model:value="data.description"
+            :maxlength="500"
+            :auto-size="{ minRows: 2, maxRows: 4 }"
+            show-count
+          />
+        </AFormItem>
         <AFormItem :label="$gettext('Updated at')">
           {{ formatDateTime(data.modified_at) }}
         </AFormItem>

--- a/app/src/views/site/site_edit/components/SiteEditor/store.ts
+++ b/app/src/views/site/site_edit/components/SiteEditor/store.ts
@@ -154,6 +154,7 @@ export const useSiteEditorStore = defineStore('siteEditor', () => {
 
       const response = await site.updateItem(encodeURIComponent(name.value), {
         content,
+        description: data.value.description,
         overwrite: true,
         namespace_id: data.value.namespace_id,
         sync_node_ids: data.value.sync_node_ids,

--- a/app/src/views/site/site_list/columns.tsx
+++ b/app/src/views/site/site_list/columns.tsx
@@ -44,6 +44,12 @@ const columns: StdTableColumn[] = [{
       <div>{text}</div>,
     )
 
+    if (record.description) {
+      template.push(
+        <div class="text-secondary mt-1">{record.description}</div>,
+      )
+    }
+
     // Add URLs below the name
     if (record.urls && record.urls.length > 0) {
       const urlsContainer: JSXElements = []

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type ProxyTarget = upstream.ProxyTarget
 
 type Config struct {
 	Name          string           `json:"name"`
+	Description   string           `json:"description,omitempty"`
 	Content       string           `json:"content"`
 	FilePath      string           `json:"filepath,omitempty"`
 	ModifiedAt    time.Time        `json:"modified_at"`

--- a/internal/site/list.go
+++ b/internal/site/list.go
@@ -49,7 +49,21 @@ func GetSiteConfigs(ctx context.Context, options *ListOptions, sites []*model.Si
 		return nil, err
 	}
 
-	return applyRemoteStatus(configs, sites, options.Status), nil
+	configs = applyRemoteStatus(configs, sites, options.Status)
+	return applySiteDescriptions(configs, sites), nil
+}
+
+func applySiteDescriptions(configs []config.Config, sites []*model.Site) []config.Config {
+	descriptions := make(map[string]string, len(sites))
+	for _, siteModel := range sites {
+		if siteModel.Description != "" {
+			descriptions[filepath.Base(siteModel.Path)] = siteModel.Description
+		}
+	}
+	for i := range configs {
+		configs[i].Description = descriptions[configs[i].Name]
+	}
+	return configs
 }
 
 // applyRemoteStatus overrides the filesystem derived status for sites owned by a

--- a/internal/site/list_test.go
+++ b/internal/site/list_test.go
@@ -1,0 +1,24 @@
+package site
+
+import (
+	"testing"
+
+	"github.com/0xJacky/Nginx-UI/internal/config"
+	"github.com/0xJacky/Nginx-UI/model"
+)
+
+func TestApplySiteDescriptions(t *testing.T) {
+	configs := []config.Config{{Name: "example.com"}, {Name: "other.conf"}}
+	sites := []*model.Site{
+		{Path: "/etc/nginx/sites-available/example.com", Description: "Customer portal"},
+		{Path: "/etc/nginx/sites-available/unlisted.conf", Description: "Unused"},
+	}
+
+	result := applySiteDescriptions(configs, sites)
+	if result[0].Description != "Customer portal" {
+		t.Fatalf("description = %q, want Customer portal", result[0].Description)
+	}
+	if result[1].Description != "" {
+		t.Fatalf("unmatched description = %q, want empty", result[1].Description)
+	}
+}

--- a/model/site.go
+++ b/model/site.go
@@ -10,6 +10,7 @@ type SiteDNSRecord struct {
 type Site struct {
 	Model
 	Path        string     `json:"path" gorm:"uniqueIndex"`
+	Description string     `json:"description"`
 	Advanced    bool       `json:"advanced"`
 	NamespaceID uint64     `json:"namespace_id"`
 	Namespace   *Namespace `json:"namespace,omitempty"`


### PR DESCRIPTION
## Summary

- persist an optional description independently from the site configuration filename
- expose the description in site detail editing with a 500-character limit
- show it below the filename in the site list
- join stored descriptions into local and remote site-list responses

Closes #1631.

## Validation

- `GOWORK=off go test -tags=unembed -race -cover -count=1 ./...`
- `bun run typecheck`
- `bun run lint`
- `bun test` (28 passed)
- `bun run build`

## AI assistance

This change was implemented and locally verified with Codex assistance. No human review is claimed.
