### PR TITLE
feat: allow maintenance bypass by IP

### DIFF
--- a/app/src/api/settings.ts
+++ b/app/src/api/settings.ts
@@ -88,6 +88,7 @@ export interface NginxSettings {
   maintenance_dir?: string
   maintenance_template?: string
   maintenance_host?: string
+  maintenance_bypass_ip?: string
   host_mode?: string
 
   // Host-via-SSH mode fields

--- a/app/src/views/preference/tabs/NginxSettings.vue
+++ b/app/src/views/preference/tabs/NginxSettings.vue
@@ -178,6 +178,15 @@ async function openSSHSetup() {
         {{ $gettext('Optional HTTP or HTTPS origin that serves the maintenance page. Leave empty to use this Nginx UI instance.') }}
       </div>
     </AFormItem>
+    <AFormItem :label="$gettext('Maintenance bypass IP')">
+      <AInput
+        v-model:value="data.nginx.maintenance_bypass_ip"
+        :placeholder="$gettext('203.0.113.10')"
+      />
+      <div class="text-secondary mt-1">
+        {{ $gettext('Requests from this IPv4 or IPv6 address continue to use the original site while maintenance mode is active.') }}
+      </div>
+    </AFormItem>
     <AFormItem :label="$gettext('Maintenance template (filename only)')">
       <AInput
         v-model:value="data.nginx.maintenance_template"

--- a/internal/site/maintenance.go
+++ b/internal/site/maintenance.go
@@ -1,6 +1,7 @@
 package site
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -309,6 +310,11 @@ func createMaintenanceConfigWithPayload(conf *config.Config, baseDir string, sit
 		schema = "https"
 	}
 	maintenanceHost := settings.NginxSettings.GetMaintenanceHost(schema, nginxUIPort)
+	if bypassIP := settings.NginxSettings.GetMaintenanceBypassIP(); bypassIP != "" {
+		if content, ok := createBypassMaintenanceConfig(conf, siteName, payload, bypassIP, maintenanceHost, schema, nginxUIPort); ok {
+			return content
+		}
+	}
 
 	// Create new configuration
 	ngxConfig := nginx.NewNgxConfig("")
@@ -422,6 +428,100 @@ func createMaintenanceConfigWithPayload(conf *config.Config, baseDir string, sit
 	}
 
 	return content
+}
+
+func createBypassMaintenanceConfig(conf *config.Config, siteName string, payload MaintenancePayload, bypassIP, maintenanceHost, schema string, nginxUIPort uint) (string, bool) {
+	original := dumper.DumpConfig(conf, dumper.IndentedStyle)
+	ngxConfig, err := nginx.ParseNgxConfigByContent(original)
+	if err != nil {
+		logger.Errorf("Failed to preserve site configuration for maintenance bypass: %v", err)
+		return "", false
+	}
+
+	digest := sha256.Sum256([]byte(siteName))
+	suffix := fmt.Sprintf("%x", digest[:4])
+	bypassVariable := "nginx_ui_maintenance_bypass_" + suffix
+	modeVariable := "nginx_ui_maintenance_mode_" + suffix
+	locationName := "@nginx_ui_maintenance_" + suffix
+	ngxConfig.Custom += fmt.Sprintf(`
+geo $%s {
+    default 0;
+    %s 1;
+}
+map "$%s:$uri" $%s {
+    default 1;
+    ~^1: 0;
+    ~^0:/\.well-known/acme-challenge/ 0;
+    ~^0:/pages/maintenance/meta$ 0;
+}
+`, bypassVariable, bypassIP, bypassVariable, modeVariable)
+
+	for _, server := range ngxConfig.Servers {
+		server.Directives = append(server.Directives,
+			&nginx.NgxDirective{Raw: fmt.Sprintf("error_page 418 = %s;", locationName)},
+			&nginx.NgxDirective{Raw: fmt.Sprintf("if ($%s) {\n    return 418;\n}", modeVariable)},
+		)
+		server.Locations = append(server.Locations, &nginx.NgxLocation{
+			Path:    locationName,
+			Content: buildMaintenanceProxyContent(siteName, payload, maintenanceHost, true),
+		})
+		if !hasMaintenanceLocation(server, "/pages/maintenance/meta") {
+			server.Locations = append(server.Locations, &nginx.NgxLocation{
+				Path:    "= /pages/maintenance/meta",
+				Content: buildMaintenanceProxyContent(siteName, payload, fmt.Sprintf("%s://127.0.0.1:%d", schema, nginxUIPort), false),
+			})
+		}
+		if !hasMaintenanceLocation(server, "/.well-known/acme-challenge") {
+			server.Locations = append(server.Locations, &nginx.NgxLocation{
+				Path: "^~ /.well-known/acme-challenge",
+				Content: "proxy_set_header Host $host;\n" +
+					"proxy_set_header X-Real-IP $remote_addr;\n" +
+					"proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n" +
+					fmt.Sprintf("proxy_pass http://127.0.0.1:%s;\n", settings.CertSettings.HTTPChallengePort),
+			})
+		}
+	}
+
+	content, err := ngxConfig.BuildConfig()
+	if err != nil {
+		logger.Errorf("Failed to build maintenance bypass configuration: %v", err)
+		return "", false
+	}
+	return content, true
+}
+
+func hasMaintenanceLocation(server *nginx.NgxServer, fragment string) bool {
+	for _, location := range server.Locations {
+		if strings.Contains(location.Path, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
+func buildMaintenanceProxyContent(siteName string, payload MaintenancePayload, host string, rewrite bool) string {
+	var content strings.Builder
+	content.WriteString("proxy_set_header Host $host;\n")
+	content.WriteString("proxy_set_header X-Real-IP $remote_addr;\n")
+	content.WriteString("proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n")
+	content.WriteString("proxy_set_header X-Forwarded-Proto $scheme;\n")
+	content.WriteString("proxy_set_header X-Forwarded-Host $http_host;\n")
+	for _, header := range []struct{ name, value string }{
+		{maintenanceSiteHeaderKey, siteName},
+		{maintenanceStartTimeHeaderKey, payload.StartTime},
+		{maintenanceEndTimeHeaderKey, payload.EndTime},
+		{maintenanceContactHeaderKey, payload.Contact},
+		{maintenanceAdditionalInfoHeaderKey, payload.AdditionInformation},
+	} {
+		if header.value != "" {
+			content.WriteString(fmt.Sprintf("proxy_set_header %s \"%s\";\n", header.name, escapeNginxQuotedValue(header.value)))
+		}
+	}
+	if rewrite {
+		content.WriteString("rewrite ^ /pages/maintenance break;\n")
+	}
+	content.WriteString(fmt.Sprintf("proxy_pass %s;\n", host))
+	return content.String()
 }
 
 // escapeNginxQuotedValue escapes a value embedded in a double quoted nginx parameter.

--- a/internal/site/maintenance_test.go
+++ b/internal/site/maintenance_test.go
@@ -22,11 +22,13 @@ func setupMaintenanceTestSettings(t *testing.T, nginxConfigDir string) {
 	originalHTTPS := cSettings.ServerSettings.EnableHTTPS
 	originalChallengePort := settings.CertSettings.HTTPChallengePort
 	originalConfigDir := settings.NginxSettings.ConfigDir
+	originalBypassIP := settings.NginxSettings.MaintenanceBypassIP
 	t.Cleanup(func() {
 		cSettings.ServerSettings.Port = originalPort
 		cSettings.ServerSettings.EnableHTTPS = originalHTTPS
 		settings.CertSettings.HTTPChallengePort = originalChallengePort
 		settings.NginxSettings.ConfigDir = originalConfigDir
+		settings.NginxSettings.MaintenanceBypassIP = originalBypassIP
 	})
 
 	if nginxConfigDir != "" {
@@ -35,6 +37,58 @@ func setupMaintenanceTestSettings(t *testing.T, nginxConfigDir string) {
 	cSettings.ServerSettings.Port = 9000
 	cSettings.ServerSettings.EnableHTTPS = false
 	settings.CertSettings.HTTPChallengePort = "9180"
+}
+
+func TestCreateMaintenanceConfig_BypassPreservesOriginalSite(t *testing.T) {
+	setupMaintenanceTestSettings(t, "")
+	settings.NginxSettings.MaintenanceBypassIP = "203.0.113.10"
+
+	p := parser.NewStringParser(`server {
+    listen 80;
+    server_name example.com;
+    root /srv/example;
+    location /api {
+        proxy_pass http://backend;
+    }
+}`, parser.WithSkipValidDirectivesErr())
+	conf, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	content := createMaintenanceConfig(conf, "", "example.com")
+	for _, expected := range []string{
+		"203.0.113.10 1;",
+		"root /srv/example;",
+		"location /api",
+		"proxy_pass http://backend;",
+		"return 418;",
+		"rewrite ^ /pages/maintenance break;",
+	} {
+		if !strings.Contains(content, expected) {
+			t.Fatalf("maintenance config missing %q:\n%s", expected, content)
+		}
+	}
+}
+
+func TestCreateMaintenanceConfig_InvalidBypassUsesRegularMaintenance(t *testing.T) {
+	setupMaintenanceTestSettings(t, "")
+	settings.NginxSettings.MaintenanceBypassIP = "203.0.113.10; return 200"
+
+	p := parser.NewStringParser(`server {
+    listen 80;
+    server_name example.com;
+    root /srv/example;
+}`, parser.WithSkipValidDirectivesErr())
+	conf, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	content := createMaintenanceConfig(conf, "", "example.com")
+	if strings.Contains(content, "203.0.113.10") || strings.Contains(content, "root /srv/example") {
+		t.Fatalf("invalid bypass leaked into maintenance config:\n%s", content)
+	}
 }
 
 func TestCreateMaintenanceConfig_PreservesForwardedHost(t *testing.T) {

--- a/settings/nginx.go
+++ b/settings/nginx.go
@@ -2,6 +2,7 @@ package settings
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 )
@@ -54,6 +55,7 @@ type Nginx struct {
 	MaintenanceDir      string   `json:"maintenance_dir" protected:"true"`
 	MaintenanceTemplate string   `json:"maintenance_template"`
 	MaintenanceHost     string   `json:"maintenance_host"`
+	MaintenanceBypassIP string   `json:"maintenance_bypass_ip"`
 
 	// Host SSH mode fields enable nginx-ui (running in Docker) to control
 	// nginx installed natively on the same host via an SSH tunnel.
@@ -108,6 +110,14 @@ func (n *Nginx) GetMaintenanceHost(defaultScheme string, defaultPort uint) strin
 	}
 
 	return parsed.Scheme + "://" + parsed.Host
+}
+
+func (n *Nginx) GetMaintenanceBypassIP() string {
+	address := net.ParseIP(strings.TrimSpace(n.MaintenanceBypassIP))
+	if address == nil {
+		return ""
+	}
+	return address.String()
 }
 
 func (n *Nginx) GetHostKnownHostsPath() string {

--- a/settings/nginx_test.go
+++ b/settings/nginx_test.go
@@ -37,6 +37,26 @@ func TestNginx_GetHostKnownHostsPath_Default(t *testing.T) {
 	}
 }
 
+func TestNginx_GetMaintenanceBypassIP(t *testing.T) {
+	tests := []struct {
+		value string
+		want  string
+	}{
+		{value: "203.0.113.10", want: "203.0.113.10"},
+		{value: " 2001:db8::1 ", want: "2001:db8::1"},
+		{value: "203.0.113.10/32", want: ""},
+		{value: "203.0.113.10; return 200", want: ""},
+		{value: "", want: ""},
+	}
+
+	for _, test := range tests {
+		nginxSettings := Nginx{MaintenanceBypassIP: test.value}
+		if got := nginxSettings.GetMaintenanceBypassIP(); got != test.want {
+			t.Errorf("GetMaintenanceBypassIP(%q) = %q, want %q", test.value, got, test.want)
+		}
+	}
+}
+
 func TestNginx_GetHostKnownHostsPath_Configured(t *testing.T) {
 	n := Nginx{HostKnownHostsPath: "/custom/known_hosts"}
 	if got := n.GetHostKnownHostsPath(); got != "/custom/known_hosts" {


### PR DESCRIPTION
## Summary

- add an optional IPv4 or IPv6 maintenance bypass address
- preserve the original server, upstream, and location configuration for that address
- route other visitors to a uniquely named maintenance handler
- preserve ACME challenge handling and maintenance metadata requests
- reject malformed values before they can enter generated Nginx configuration

Closes #1844.

## Validation

- `GOWORK=off go test -tags=unembed -race -cover -count=1 ./...`
- `bun run typecheck`
- `bun run lint`
- `bun test` (28 passed)
- `bun run build`

## AI assistance

This change was implemented and locally verified with Codex assistance. No human review is claimed.
