### PR TITLE
fix(upstream): Add a fallback-to-TCP mechanism for availability probes when the TLS handshake fails.

### DIFF
--- a/internal/upstream/upstream.go
+++ b/internal/upstream/upstream.go
@@ -148,8 +148,9 @@ func testTLSLatency(workers chan struct{}, wg *sync.WaitGroup, target ProxyTarge
 	}()
 
 	start := time.Now()
+	address := formatSocketAddress(target.Host, target.Port)
 	dialer := &net.Dialer{Timeout: MaxTimeout}
-	conn, err := tls.DialWithDialer(dialer, "tcp", formatSocketAddress(target.Host, target.Port), &tls.Config{
+	conn, err := tls.DialWithDialer(dialer, "tcp", address, &tls.Config{
 		// Availability checks validate that the endpoint can negotiate TLS. They
 		// intentionally do not duplicate certificate-policy validation performed
 		// by the real proxy request, which may use a private CA or an IP address.
@@ -157,6 +158,17 @@ func testTLSLatency(workers chan struct{}, wg *sync.WaitGroup, target ProxyTarge
 		ServerName:         target.Host,
 	})
 	if err != nil {
+		// Some HTTPS backends intentionally reject generic probe handshakes
+		// (for example mTLS-only policies). Fall back to plain TCP reachability
+		// so the availability check still reflects whether the socket is up.
+		tcpConn, tcpErr := net.DialTimeout("tcp", address, MaxTimeout)
+		if tcpErr != nil {
+			return
+		}
+		defer tcpConn.Close()
+
+		status.Online = true
+		status.Latency = float32(time.Since(start)) / float32(time.Millisecond)
 		return
 	}
 	defer conn.Close()

--- a/internal/upstream/upstream_tls_e2e_test.go
+++ b/internal/upstream/upstream_tls_e2e_test.go
@@ -112,6 +112,49 @@ server {
 	}
 }
 
+func TestHTTPSProbeFallsBackToTCPWhenTLSHandshakeFails(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen tcp: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+
+	stop := make(chan struct{})
+	go func() {
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				select {
+				case <-stop:
+					return
+				default:
+					return
+				}
+			}
+			_ = conn.Close()
+		}
+	}()
+	t.Cleanup(func() {
+		close(stop)
+	})
+
+	host, port, splitErr := net.SplitHostPort(listener.Addr().String())
+	if splitErr != nil {
+		t.Fatalf("split listener addr: %v", splitErr)
+	}
+
+	target := ProxyTarget{Host: host, Port: port, Type: "proxy_pass", Scheme: "https"}
+	results := AvailabilityTestTargets([]ProxyTarget{target})
+	socket := formatSocketAddress(host, port)
+	status := results[socket]
+
+	if status == nil || !status.Online {
+		t.Fatalf("status = %+v, want online when TCP socket is reachable", status)
+	}
+}
+
 type synchronizedLog struct {
 	mu      sync.Mutex
 	buffer  bytes.Buffer


### PR DESCRIPTION
## Summary

When an upstream is configured with HTTPS, availability checks may be marked as offline if the TLS handshake fails, even though the target TCP port is still reachable.

This change adds a fallback-to-TCP mechanism for HTTPS probes. If the TLS handshake fails but the TCP connection can still be established, the upstream will be reported as online.

## Problem

A reachable HTTPS endpoint may be shown as offline in the UI when TLS negotiation fails.

## Solution

- Try HTTPS/TLS probe first.
- Fall back to a TCP connectivity check when the TLS handshake fails.
- Mark the upstream as online if the TCP socket is reachable.

## Test

- Added a unit test covering the TLS handshake failure scenario and verifying fallback to TCP connectivity detection.