### PR TITLE
fix: parse site check URLs safely

### DIFF
--- a/model/site_config.go
+++ b/model/site_config.go
@@ -1,6 +1,9 @@
 package model
 
 import (
+	"fmt"
+	"net"
+	"net/url"
 	"strconv"
 	"strings"
 )
@@ -74,54 +77,43 @@ func (sc *SiteConfig) GetURL() string {
 }
 
 // SetFromURL parses a URL and sets the Host, Port, and Scheme fields
-func (sc *SiteConfig) SetFromURL(url string) error {
-	// Parse URL to extract host, port, and scheme
-	// This is a simplified implementation - you may want to use net/url package
-	if url == "" {
+func (sc *SiteConfig) SetFromURL(value string) error {
+	rawURL := strings.TrimSpace(value)
+	if rawURL == "" {
 		return nil
 	}
 
 	// Store the original URL as display URL for backward compatibility
-	sc.DisplayURL = url
-
-	// Extract scheme
-	if strings.HasPrefix(url, "https://") {
-		sc.Scheme = "https"
-		url = strings.TrimPrefix(url, "https://")
-	} else if strings.HasPrefix(url, "http://") {
-		sc.Scheme = "http"
-		url = strings.TrimPrefix(url, "http://")
-	} else if strings.HasPrefix(url, "grpcs://") {
-		sc.Scheme = "grpcs"
-		url = strings.TrimPrefix(url, "grpcs://")
-	} else if strings.HasPrefix(url, "grpc://") {
-		sc.Scheme = "grpc"
-		url = strings.TrimPrefix(url, "grpc://")
-	} else {
-		sc.Scheme = "http" // default
+	sc.DisplayURL = value
+	if !strings.Contains(rawURL, "://") {
+		rawURL = "http://" + rawURL
 	}
 
-	// Extract host and port
-	if strings.Contains(url, "/") {
-		url = strings.Split(url, "/")[0]
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Hostname() == "" {
+		return fmt.Errorf("invalid site URL %q", value)
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "http" && scheme != "https" && scheme != "grpc" && scheme != "grpcs" {
+		return fmt.Errorf("unsupported site URL scheme %q", parsed.Scheme)
 	}
 
-	if strings.Contains(url, ":") {
-		parts := strings.Split(url, ":")
-		sc.Host = parts[0] + ":" + parts[1]
-		if len(parts) > 1 {
-			if port, err := strconv.Atoi(parts[1]); err == nil {
-				sc.Port = port
-			}
-		}
-	} else {
-		sc.Host = url + ":80" // default port
-		sc.Port = 80
-		if sc.Scheme == "https" || sc.Scheme == "grpcs" {
-			sc.Host = url + ":443"
-			sc.Port = 443
+	portText := parsed.Port()
+	if portText == "" {
+		if scheme == "https" || scheme == "grpcs" {
+			portText = "443"
+		} else {
+			portText = "80"
 		}
 	}
+	port, err := strconv.Atoi(portText)
+	if err != nil || port < 1 || port > 65535 {
+		return fmt.Errorf("invalid site URL port %q", portText)
+	}
+
+	sc.Scheme = scheme
+	sc.Port = port
+	sc.Host = net.JoinHostPort(parsed.Hostname(), portText)
 
 	return nil
 }

--- a/model/site_config_test.go
+++ b/model/site_config_test.go
@@ -1,0 +1,43 @@
+package model
+
+import "testing"
+
+func TestSiteConfigSetFromURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		wantScheme string
+		wantHost   string
+		wantPort   int
+	}{
+		{name: "http default", url: "http://example.com/path", wantScheme: "http", wantHost: "example.com:80", wantPort: 80},
+		{name: "https explicit", url: "https://example.com:8443/path", wantScheme: "https", wantHost: "example.com:8443", wantPort: 8443},
+		{name: "IPv6 default", url: "https://[2001:db8::1]/health", wantScheme: "https", wantHost: "[2001:db8::1]:443", wantPort: 443},
+		{name: "IPv6 explicit", url: "grpc://[2001:db8::2]:50051/service", wantScheme: "grpc", wantHost: "[2001:db8::2]:50051", wantPort: 50051},
+		{name: "scheme omitted", url: "example.com:8080/status", wantScheme: "http", wantHost: "example.com:8080", wantPort: 8080},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := &SiteConfig{}
+			if err := config.SetFromURL(test.url); err != nil {
+				t.Fatalf("SetFromURL() error = %v", err)
+			}
+			if config.Scheme != test.wantScheme || config.Host != test.wantHost || config.Port != test.wantPort {
+				t.Fatalf("SetFromURL() = scheme %q, host %q, port %d; want %q, %q, %d", config.Scheme, config.Host, config.Port, test.wantScheme, test.wantHost, test.wantPort)
+			}
+			if config.DisplayURL != test.url {
+				t.Fatalf("DisplayURL = %q, want original %q", config.DisplayURL, test.url)
+			}
+		})
+	}
+}
+
+func TestSiteConfigSetFromURLRejectsInvalidInputs(t *testing.T) {
+	for _, rawURL := range []string{"ftp://example.com", "http://", "https://example.com:70000"} {
+		config := &SiteConfig{}
+		if err := config.SetFromURL(rawURL); err == nil {
+			t.Errorf("SetFromURL(%q) error = nil", rawURL)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- replace manual colon splitting in site health-check URL parsing with `net/url`
- preserve explicit ports and select protocol defaults consistently
- support bracketed IPv6 addresses without truncating them
- reject unsupported schemes, missing hosts, and out-of-range ports

The previous parser treated any colon as a host/port separator. An IPv6 URL such as `https://[2001:db8::1]/health` therefore produced an invalid host and port, while malformed ports could silently leave partially populated configuration.

## Validation

- `GOWORK=off go test -tags=unembed -race -cover -count=1 ./...`
- `GOWORK=off go vet -tags=unembed ./model ./internal/sitecheck`

## AI assistance

This change was implemented and locally verified with Codex assistance. No human review is claimed.
