### PR TITLE
fix: preserve escaped node URLs

### DIFF
--- a/model/node.go
+++ b/model/node.go
@@ -101,29 +101,19 @@ type NodeControllerCredential struct {
 	RevokedAt            *time.Time `json:"revoked_at,omitempty" gorm:"index"`
 }
 
-func (n *Node) GetUrl(uri string) (decodedUri string, err error) {
+func (n *Node) GetUrl(uri string) (string, error) {
 	baseUrl, err := url.Parse(n.URL)
 	if err != nil {
-		return
+		return "", err
 	}
 
-	u, err := url.JoinPath(baseUrl.String(), uri)
-	if err != nil {
-		return
-	}
-
-	decodedUri, err = url.QueryUnescape(u)
-	if err != nil {
-		return
-	}
-
-	return
+	return joinNodeURL(baseUrl, uri)
 }
 
-func (n *Node) GetWebSocketURL(uri string) (decodedUri string, err error) {
+func (n *Node) GetWebSocketURL(uri string) (string, error) {
 	baseUrl, err := url.Parse(n.URL)
 	if err != nil {
-		return
+		return "", err
 	}
 
 	// Switch the scheme on the parsed URL instead of rewriting the rendered
@@ -143,17 +133,23 @@ func (n *Node) GetWebSocketURL(uri string) (decodedUri string, err error) {
 		baseUrl.Host = net.JoinHostPort(baseUrl.Hostname(), defaultPort)
 	}
 
-	u, err := url.JoinPath(baseUrl.String(), uri)
+	return joinNodeURL(baseUrl, uri)
+}
 
+func joinNodeURL(baseURL *url.URL, uri string) (string, error) {
+	reference, err := url.Parse(uri)
 	if err != nil {
-		return
+		return "", err
 	}
-
-	decodedUri, err = url.QueryUnescape(u)
-
+	joined, err := url.JoinPath(baseURL.String(), reference.EscapedPath())
 	if err != nil {
-		return
+		return "", err
 	}
-
-	return
+	result, err := url.Parse(joined)
+	if err != nil {
+		return "", err
+	}
+	result.RawQuery = reference.RawQuery
+	result.Fragment = reference.Fragment
+	return result.String(), nil
 }

--- a/model/node_test.go
+++ b/model/node_test.go
@@ -45,6 +45,12 @@ func TestNodeGetWebSocketURL(t *testing.T) {
 			uri:  "/api/nginx_log?type=http",
 			want: "wss://node.example.com:9000/api/nginx_log?type=http",
 		},
+		{
+			name: "escaped query data remains escaped",
+			url:  "https://node.example.com:9000",
+			uri:  "/api/configs?name=folder%2Fsite+copy",
+			want: "wss://node.example.com:9000/api/configs?name=folder%2Fsite+copy",
+		},
 	}
 
 	for _, test := range tests {
@@ -58,5 +64,17 @@ func TestNodeGetWebSocketURL(t *testing.T) {
 				t.Fatalf("expected %q, got %q", test.want, got)
 			}
 		})
+	}
+}
+
+func TestNodeGetURLPreservesEscapedComponents(t *testing.T) {
+	node := &Node{URL: "https://node.example.com/nginx%20ui"}
+	got, err := node.GetUrl("/api/configs?name=folder%2Fsite+copy")
+	if err != nil {
+		t.Fatalf("GetUrl returned error: %v", err)
+	}
+	want := "https://node.example.com/nginx%20ui/api/configs?name=folder%2Fsite+copy"
+	if got != want {
+		t.Fatalf("GetUrl() = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

- parse node request references before joining them to the configured base path
- preserve escaped path components, query delimiters, and query values
- remove whole-URL `QueryUnescape` calls that could turn `%2F` into a path separator and `+` into a space
- apply the same safe join behavior to HTTP and WebSocket node URLs

Previously, joining a request URI encoded its `?` delimiter as path data and then decoded the entire result to compensate. That also decoded user-controlled escaped components and could change the request target sent to a node.

## Validation

- `GOWORK=off go test -tags=unembed -race -cover -count=1 ./...`
- `GOWORK=off go vet -tags=unembed ./model ./internal/config ./internal/nodeauth ./internal/middleware`

## AI assistance

This change was implemented and locally verified with Codex assistance. No human review is claimed.
