### PR TITLE
feat(nginx-log): improve access log path selection UX and support query path binding

### DIFF
--- a/app/src/api/nginx_log.ts
+++ b/app/src/api/nginx_log.ts
@@ -23,6 +23,16 @@ export interface NginxLogData {
   partial_offset?: number
 }
 
+export interface LogListResponse {
+  data: NginxLogData[]
+  summary?: {
+    total_files?: number
+    indexed_files?: number
+    indexing_files?: number
+    document_count?: number
+  }
+}
+
 export interface AnalyticsRequest {
   path: string
   start_time?: number
@@ -319,6 +329,10 @@ export interface GeoStats {
 }
 
 const nginx_log = extendCurdApi(useCurdApi('/nginx_logs'), {
+  list(params?: Pick<NginxLogData, 'type' | 'name' | 'path'>): Promise<LogListResponse> {
+    return http.get('/nginx_logs', { params })
+  },
+
   page(page = 0, data: NginxLogData | undefined = undefined) {
     return http.post(`/nginx_log/page?page=${page}`, data)
   },

--- a/app/src/views/nginx_log/NginxLog.vue
+++ b/app/src/views/nginx_log/NginxLog.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { FileOutlined } from '@antdv-next/icons'
 import { useRouteQuery } from '@vueuse/router'
 import nginxLog from '@/api/nginx_log'
 import FooterToolBar from '@/components/FooterToolbar'
@@ -21,6 +20,96 @@ const logType = computed(() => {
 
 const viewMode = useRouteQuery<'raw' | 'structured' | 'dashboard'>('view', 'structured')
 
+interface LogPathOption {
+  label: string
+  value: string
+}
+
+const logPathOptions = ref<LogPathOption[]>([])
+const isLoadingLogPathOptions = ref(false)
+
+const maxLogPathLength = computed(() => {
+  const optionMax = logPathOptions.value.reduce((max, option) => {
+    return Math.max(max, option.label.length)
+  }, 0)
+  return Math.max(optionMax, logPath.value.length, 20)
+})
+
+const logSelectStyle = computed(() => ({
+  width: `min(calc(100vw - 4rem), ${maxLogPathLength.value + 8}ch)`,
+  minWidth: '20rem',
+}))
+
+const logSelectDropdownStyle = computed(() => ({
+  width: `min(calc(100vw - 2rem), ${maxLogPathLength.value + 12}ch)`,
+  minWidth: '20rem',
+}))
+
+const selectedLogPath = computed({
+  get: () => logPath.value,
+  set: (value: string) => {
+    const query = { ...route.query }
+    if (value) {
+      query.path = value
+    }
+    else {
+      delete query.path
+    }
+    router.replace({ query })
+  },
+})
+
+function normalizePath(path: string) {
+  return path.replace(/\\/g, '/')
+}
+
+function ensureCurrentPathOption(path: string) {
+  if (!path)
+    return
+
+  const normalizedCurrent = normalizePath(path)
+  const exists = logPathOptions.value.some(option => normalizePath(option.value) === normalizedCurrent)
+  if (!exists) {
+    logPathOptions.value.unshift({
+      label: path,
+      value: path,
+    })
+  }
+}
+
+async function fetchLogPathOptions() {
+  if (logType.value !== 'access' && logType.value !== 'error') {
+    logPathOptions.value = []
+    return
+  }
+
+  isLoadingLogPathOptions.value = true
+  try {
+    const res = await nginxLog.list({ type: logType.value })
+    const logs = Array.isArray(res?.data) ? res.data : []
+
+    logPathOptions.value = logs
+      .filter(item => !!item.path)
+      .map(item => ({
+        label: item.path!,
+        value: item.path!,
+      }))
+
+    ensureCurrentPathOption(logPath.value)
+
+    if (!selectedLogPath.value && logPathOptions.value.length > 0) {
+      selectedLogPath.value = logPathOptions.value[0].value
+    }
+  }
+  catch (err) {
+    console.error('Failed to load log path options:', err)
+    ensureCurrentPathOption(logPath.value)
+  }
+  finally {
+    isLoadingLogPathOptions.value = false
+  }
+}
+
 // Indexing status
 const isIndexingEnabled = ref(false)
 
@@ -33,6 +122,16 @@ onMounted(async () => {
     console.error('Failed to get indexing status:', err)
     isIndexingEnabled.value = false
   }
+
+  await fetchLogPathOptions()
+})
+
+watch(logType, async () => {
+  await fetchLogPathOptions()
+})
+
+watch(logPath, newPath => {
+  ensureCurrentPathOption(newPath)
 })
 
 // Check if this is an error log
@@ -76,14 +175,22 @@ watch([isErrorLog, isIndexingEnabled], ([isError, enabled], [prevIsError, prevEn
     :title="$gettext('Nginx Log')"
     variant="borderless"
   >
-    <!-- Log Path Header -->
-    <div v-if="logPath" class="mb-4 px-2 py-1.5 bg-gray-50 dark:bg-gray-800 rounded text-xs text-gray-500 dark:text-gray-400">
-      <FileOutlined class="mr-2" />
-      <span class="font-mono">{{ logPath }}</span>
-    </div>
-
     <template #extra>
-      <div class="flex items-center gap-4">
+      <div class="flex flex-wrap items-center justify-end gap-4">
+        <ASelect
+          v-model:value="selectedLogPath"
+          class="flex-none font-mono"
+          :style="logSelectStyle"
+          :dropdown-style="logSelectDropdownStyle"
+          show-search
+          allow-clear
+          :loading="isLoadingLogPathOptions"
+          :options="logPathOptions"
+          :placeholder="$gettext('Select log file')"
+          :filter-option="(input, option) =>
+            ((option?.label ?? '') as string).toLowerCase().includes(input.toLowerCase())"
+        />
+
         <!-- View Mode Toggle (hide for error logs or when indexing is disabled) -->
         <div v-if="!isErrorLog && isIndexingEnabled" class="flex items-center">
           <ASegmented


### PR DESCRIPTION
# Summary

This PR improves the Nginx Log page by replacing the redundant read-only log path display with a selectable log path dropdown and optimizing path visibility for long file paths.

## What Changed

- Added log path dropdown options loaded dynamically from the backend log list API for access and error logs.
- Bound the selected dropdown value to the URL query parameter `path`, enabling deep links such as:
  ```
  ?path=D:/OpCon/GIT/nginx-ui/nginx/logs/access.log
  ```
  The dropdown selection and URL are kept synchronized.
- Removed the top read-only log path banner to eliminate duplicated information.
- Updated dropdown option rendering to display the full log path for easier identification.
- Added dynamic width calculation based on the longest log path to improve visibility:
  - Select input width
  - Dropdown panel width
- Improved the header extra layout to support wrapping and reduce truncation caused by horizontal compression.

## UX Impact

- Long log paths are significantly less likely to be truncated.
- Users can switch between log files directly from the dropdown.
- Shared URLs containing a query `path` parameter correctly open and select the target log file.

## Files Changed

- `NginxLog.vue`

## Verification

1. Open the Nginx Log Access Logs page with a query `path` parameter and confirm the selected dropdown option matches the URL.
2. Switch between dropdown options and verify the URL query `path` updates immediately.
3. Verify long path entries are displayed more clearly in:
   - The selected dropdown value
   - The dropdown option list
4. Confirm existing view mode behavior remains unchanged for:
   - Raw view
   - Structured view
   - Dashboard view

## Notes

- Project-wide type checking currently reports pre-existing unrelated errors, primarily caused by Axios type mismatch chains.
- No new errors were introduced in `NginxLog.vue`.

## Screenshot Checklist

- [x] Before vs. after comparison showing the removal of the read-only path banner.
- [x] Long log path displayed as the selected dropdown value.
- [x] Long log path displayed in the dropdown list without obvious truncation.
<img width="1662" height="586" alt="image" src="https://github.com/user-attachments/assets/e6823d81-a2a5-4343-9639-e8e6d2e7b8a2" />
