### PR TITLE
Dashboard: add hostname and IP address in Server Info

### DIFF
--- a/api/analytic/analytic.go
+++ b/api/analytic/analytic.go
@@ -177,8 +177,14 @@ func GetAnalyticInit(c *gin.Context) {
 		loadAvg = &load.AvgStat{}
 	}
 
+	ipAddresses, err := analytic.GetHostIPAddresses()
+	if err != nil {
+		logger.Error(err)
+	}
+
 	c.JSON(http.StatusOK, InitResp{
-		Host: hostInfo,
+		Host:        hostInfo,
+		IPAddresses: ipAddresses,
 		CPU: CPURecords{
 			Info:  cpuInfo,
 			User:  analytic.CpuUserRecord,

--- a/api/analytic/type.go
+++ b/api/analytic/type.go
@@ -43,11 +43,12 @@ type DiskIORecords struct {
 }
 
 type InitResp struct {
-	Host    *host.InfoStat    `json:"host"`
-	CPU     CPURecords        `json:"cpu"`
-	Network NetworkRecords    `json:"network"`
-	DiskIO  DiskIORecords     `json:"disk_io"`
-	Memory  analytic.MemStat  `json:"memory"`
-	Disk    analytic.DiskStat `json:"disk"`
-	LoadAvg *load.AvgStat     `json:"loadavg"`
+	Host        *host.InfoStat    `json:"host"`
+	IPAddresses []string          `json:"ip_addresses"`
+	CPU         CPURecords        `json:"cpu"`
+	Network     NetworkRecords    `json:"network"`
+	DiskIO      DiskIORecords     `json:"disk_io"`
+	Memory      analytic.MemStat  `json:"memory"`
+	Disk        analytic.DiskStat `json:"disk"`
+	LoadAvg     *load.AvgStat     `json:"loadavg"`
 }

--- a/app/src/api/analytic.ts
+++ b/app/src/api/analytic.ts
@@ -107,6 +107,7 @@ export interface DiskIORecords {
 
 export interface AnalyticInit {
   host: HostInfoStat
+  ip_addresses: string[]
   cpu: CPURecords
   network: NetworkRecords
   disk_io: DiskIORecords

--- a/app/src/views/dashboard/ServerAnalytic.vue
+++ b/app/src/views/dashboard/ServerAnalytic.vue
@@ -64,6 +64,7 @@ const disk_io = reactive({ writes: 0, reads: 0 })
 const uptime = ref('')
 const loadavg = reactive({ load1: 0, load5: 0, load15: 0 }) as LoadStat
 const net = reactive({ recv: 0, sent: 0, last_recv: 0, last_sent: 0 })
+const ipAddresses = ref<string[]>([])
 
 interface NetworkSample {
   bytesRecv: number
@@ -126,6 +127,7 @@ onMounted(async () => {
   Object.assign(cpu_info, r.cpu.info)
   Object.assign(memory, r.memory)
   Object.assign(disk, r.disk)
+  ipAddresses.value = r.ip_addresses ?? []
 
   // uptime
   handle_uptime(r.host?.uptime)
@@ -248,6 +250,14 @@ function wsOnMessage(m: MessageEvent) {
             <span class="os-platform">{{ ` ${host.platform}` }}</span> {{ host.platformVersion }}
             <span class="os-info">({{ host.os }} {{ host.kernelVersion }}
               {{ host.kernelArch }})</span>
+          </p>
+          <p>
+            {{ `${$gettext('Host')}:` }}
+            {{ host.hostname || 'N/A' }}
+          </p>
+          <p>
+            {{ `${$gettext('IP Address')}:` }}
+            <span class="ip-addresses">{{ ipAddresses.length > 0 ? ipAddresses.join(', ') : 'N/A' }}</span>
           </p>
           <p v-if="cpu_info">
             {{ `${$gettext('CPU:')} ` }}
@@ -521,5 +531,9 @@ function wsOnMessage(m: MessageEvent) {
   @media (min-width: 1790px) or (max-width: 1200px) {
     display: none;
   }
+}
+
+.ip-addresses {
+  word-break: break-all;
 }
 </style>

--- a/internal/analytic/network.go
+++ b/internal/analytic/network.go
@@ -3,6 +3,7 @@ package analytic
 import (
 	"fmt"
 	stdnet "net"
+	"sort"
 	"strings"
 
 	"github.com/shirou/gopsutil/v4/net"
@@ -150,6 +151,64 @@ func GetNetworkStat() (data *net.IOCountersStat, err error) {
 		Fifoin:      totalFifoIn,
 		Fifoout:     totalFifoOut,
 	}, nil
+}
+
+func GetHostIPAddresses() ([]string, error) {
+	interfaces, err := stdnet.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+
+	ipSet := make(map[string]struct{})
+
+	for _, iface := range interfaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			logger.Error(err)
+			continue
+		}
+
+		ifaceInfo := networkInterfaceInfo{
+			Name:         iface.Name,
+			Flags:        iface.Flags,
+			HardwareAddr: iface.HardwareAddr,
+			Addrs:        addrs,
+		}
+
+		if !shouldCountNetworkInterface(ifaceInfo) {
+			continue
+		}
+
+		for _, addr := range addrs {
+			ip, _, err := stdnet.ParseCIDR(addr.String())
+			if err != nil {
+				continue
+			}
+
+			if !ip.IsGlobalUnicast() {
+				continue
+			}
+
+			if ip.IsLinkLocalUnicast() || ip.IsLoopback() || ip.IsMulticast() || ip.IsUnspecified() {
+				continue
+			}
+
+			if isReservedIP(ip) {
+				continue
+			}
+
+			ipSet[ip.String()] = struct{}{}
+		}
+	}
+
+	ipAddresses := make([]string, 0, len(ipSet))
+	for ip := range ipSet {
+		ipAddresses = append(ipAddresses, ip)
+	}
+
+	sort.Strings(ipAddresses)
+
+	return ipAddresses, nil
 }
 
 // isVirtualInterface checks if the interface is a virtual one based on name patterns


### PR DESCRIPTION
# Summary

This PR adds hostname and IP address visibility to the Server Info card on the Dashboard Server page.

## Changes

### Backend
- Added host IP collection during dashboard initialization.
- Exposed new response field: `ip_addresses`.
- Reused existing IP/interface filtering rules.
- Deduplicated and sorted IP addresses.

### Frontend
- Extended analytics init types with `ip_addresses`.
- Added **Host** and **IP Address** display in the Server Info card.
- Added `N/A` fallback when data is unavailable.
- Improved handling for long or multiple IP addresses to prevent layout overflow.

## Why

Allows users to quickly identify the current machine and its IP addresses directly from the dashboard, which is especially useful in multi-node or remote environments.

## Validation

- Backend compile check passed:
  ```bash
  go test -tags=unembed ./api/analytic ./internal/analytic -run TestDoesNotExist
  ```
- No diagnostics errors in modified files.
- Existing frontend typecheck issues are unrelated to this PR.

## Compatibility

- Backward compatible API change.
- New field is additive and does not affect existing consumers.
- UI changes are limited to the Server Info card.

## Risk

Low risk. Existing interface and IP filtering logic minimizes environment-specific network interface issues.

## Manual Testing

- [x] Open **Dashboard → Server**.
- [x] Confirm **Host** is displayed.
- [x] Confirm **IP Address** is displayed.
- [x] Verify `N/A` is shown when IP data is unavailable.
- [x] Verify long IP values do not overflow the layout.