### PR TITLE
fix: format dynamic upstream IPv6 addresses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.213
 	github.com/mark3labs/mcp-go v1.0.0
+	github.com/miekg/dns v1.1.73
 	github.com/minio/minio-go/v7 v7.3.0
 	github.com/minio/selfupdate v0.6.0
 	github.com/nikoksr/notify v1.6.0
@@ -235,7 +236,6 @@ require (
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/mattn/go-sqlite3 v1.14.48 // indirect
-	github.com/miekg/dns v1.1.73 // indirect
 	github.com/mimuret/golang-iij-dpf v0.9.1 // indirect
 	github.com/minio/crc64nvme v1.1.1 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect

--- a/internal/upstream/README.md
+++ b/internal/upstream/README.md
@@ -1,0 +1,10 @@
+# Upstream availability checks
+
+Dynamic service checks use the configured DNS resolver for SRV records and target
+address lookups. Resolved sockets must use `net.JoinHostPort` so IPv6 addresses
+remain bracketed for the TCP availability probe. This also applies to the address
+lookup fallback, which uses port 80; SRV results retain the advertised port.
+
+`TestResolveServiceFormatsIPv6Addresses` exercises the production resolver with a
+loopback DNS server. It covers IPv4 and IPv6 answers through both resolution paths
+without querying public DNS.

--- a/internal/upstream/dynamic_resolver.go
+++ b/internal/upstream/dynamic_resolver.go
@@ -43,6 +43,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -103,7 +104,7 @@ func (dr *DynamicResolver) ResolveService(serviceURL string) ([]string, error) {
 		// Return IP addresses with default port (80)
 		var addresses []string
 		for _, ip := range ips {
-			addresses = append(addresses, fmt.Sprintf("%s:80", ip.IP.String()))
+			addresses = append(addresses, net.JoinHostPort(ip.IP.String(), "80"))
 		}
 		return addresses, nil
 	}
@@ -118,7 +119,7 @@ func (dr *DynamicResolver) ResolveService(serviceURL string) ([]string, error) {
 		}
 
 		for _, ip := range ips {
-			addresses = append(addresses, fmt.Sprintf("%s:%d", ip.IP.String(), srv.Port))
+			addresses = append(addresses, net.JoinHostPort(ip.IP.String(), strconv.Itoa(int(srv.Port))))
 		}
 	}
 

--- a/internal/upstream/dynamic_resolver_ipv6_test.go
+++ b/internal/upstream/dynamic_resolver_ipv6_test.go
@@ -1,0 +1,76 @@
+package upstream
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+// Exercise the production resolver against loopback DNS, including both SRV
+// resolution and its address-lookup fallback. No public DNS queries are needed.
+func TestResolveServiceFormatsIPv6Addresses(t *testing.T) {
+	for _, fallback := range []bool{false, true} {
+		name := "srv"
+		if fallback {
+			name = "address_fallback"
+		}
+		t.Run(name, func(t *testing.T) {
+			conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+			require.NoError(t, err)
+			server := &dns.Server{PacketConn: conn, Handler: dns.HandlerFunc(func(w dns.ResponseWriter, request *dns.Msg) {
+				response := new(dns.Msg)
+				response.SetReply(request)
+				for _, question := range request.Question {
+					header := dns.RR_Header{Name: question.Name, Class: dns.ClassINET, Ttl: 60}
+					switch question.Qtype {
+					case dns.TypeSRV:
+						if !fallback {
+							header.Rrtype = dns.TypeSRV
+							response.Answer = append(response.Answer, &dns.SRV{Hdr: header, Port: 8080, Target: "backend.example.test."})
+						}
+					case dns.TypeA:
+						header.Rrtype = dns.TypeA
+						response.Answer = append(response.Answer, &dns.A{Hdr: header, A: net.ParseIP("192.0.2.10")})
+					case dns.TypeAAAA:
+						header.Rrtype = dns.TypeAAAA
+						response.Answer = append(response.Answer, &dns.AAAA{Hdr: header, AAAA: net.ParseIP("2001:db8::10")})
+					}
+				}
+				_ = w.WriteMsg(response)
+			})}
+			started := make(chan struct{})
+			server.NotifyStartedFunc = func() { close(started) }
+			done := make(chan error, 1)
+			go func() { done <- server.ActivateAndServe() }()
+			select {
+			case <-started:
+			case err := <-done:
+				_ = conn.Close()
+				t.Fatalf("DNS server exited before startup: %v", err)
+			case <-time.After(5 * time.Second):
+				_ = conn.Close()
+				t.Fatal("DNS server did not start")
+			}
+			t.Cleanup(func() {
+				require.NoError(t, server.Shutdown())
+				require.NoError(t, <-done)
+			})
+
+			addresses, err := NewDynamicResolver(conn.LocalAddr().String()).ResolveService("example.test service=http resolve")
+			require.NoError(t, err)
+			port := "8080"
+			if fallback {
+				port = "80"
+			}
+			require.ElementsMatch(t, []string{"192.0.2.10:" + port, "[2001:db8::10]:" + port}, addresses)
+			for _, address := range addresses {
+				_, actualPort, err := net.SplitHostPort(address)
+				require.NoError(t, err)
+				require.Equal(t, port, actualPort)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Dynamic upstream checks format resolved IPv6 addresses as `2001:db8::10:8080`, which cannot be dialed as a host/port pair. Use `net.JoinHostPort` for both SRV results and the address-lookup fallback, preserving IPv4 behavior and the selected port.

A loopback DNS regression test exercises the production resolver with IPv4 and IPv6 answers through both paths. Both IPv6 cases fail on unchanged `dev` and pass with the fix.

Validation: full uncached race-enabled Go suite (`GOWORK=off go test -tags=unembed -race -cover -count=1 ./...`) and focused upstream tests.

AI assistance: implemented and locally tested with Codex. No human review is claimed.
