### PR TITLE
fix: exclude active archive from directory backups

### DIFF
--- a/docs/guide/config-backup.md
+++ b/docs/guide/config-backup.md
@@ -69,6 +69,9 @@ For custom directory backups:
 - **No Encryption**: Custom directory backups are stored as standard ZIP files without encryption
 - **Path Validation**: Source directories must be within `GrantedAccessPath` boundaries
 - **Flexible Content**: Can backup any directory structure within allowed paths
+- **Output Exclusion**: If the destination is inside the source directory, the
+  archive being created is excluded from its own contents. Existing backup files
+  remain included; choose a separate storage directory to avoid archiving them.
 
 ## Storage Configuration
 

--- a/internal/backup/backup_zip.go
+++ b/internal/backup/backup_zip.go
@@ -20,6 +20,10 @@ func createZipArchive(zipPath, srcDir string) error {
 		return cosy.WrapErrorWithParams(ErrCreateZipFile, err.Error())
 	}
 	defer zipFile.Close()
+	outputInfo, err := zipFile.Stat()
+	if err != nil {
+		return err
+	}
 
 	// Create a new zip writer
 	zipWriter := zip.NewWriter(zipFile)
@@ -29,6 +33,12 @@ func createZipArchive(zipPath, srcDir string) error {
 	err = filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
+		}
+
+		// A local destination may be inside the source tree. Do not read the
+		// archive while writing it, including through a hard-link alias.
+		if os.SameFile(info, outputInfo) {
+			return nil
 		}
 
 		// Get relative path

--- a/internal/backup/backup_zip_output_test.go
+++ b/internal/backup/backup_zip_output_test.go
@@ -1,0 +1,57 @@
+package backup
+
+import (
+	"archive/zip"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateZipArchiveExcludesOutput(t *testing.T) {
+	for _, location := range []string{"source", "nested", "outside", "hard_link"} {
+		t.Run(location, func(t *testing.T) {
+			source := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(source, "config.txt"), []byte("configuration"), 0600))
+			// Existing archives are still user data and must not be excluded.
+			require.NoError(t, os.WriteFile(filepath.Join(source, "previous.zip"), []byte("previous backup"), 0600))
+			destination := source
+			switch location {
+			case "nested":
+				destination = filepath.Join(source, "backups")
+				require.NoError(t, os.Mkdir(destination, 0700))
+			case "outside":
+				destination = t.TempDir()
+			}
+			output := filepath.Join(destination, "current.zip")
+			if location == "hard_link" {
+				require.NoError(t, os.WriteFile(output, nil, 0600))
+				if err := os.Link(output, filepath.Join(source, "alias.zip")); err != nil {
+					t.Skipf("hard links unavailable: %v", err)
+				}
+			}
+			require.NoError(t, createZipArchive(output, source))
+			archive, err := zip.OpenReader(output)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, archive.Close()) })
+			files := make(map[string]string)
+			for _, entry := range archive.File {
+				if entry.FileInfo().IsDir() {
+					continue
+				}
+				reader, err := entry.Open()
+				require.NoError(t, err)
+				content, err := io.ReadAll(reader)
+				require.NoError(t, err)
+				require.NoError(t, reader.Close())
+				files[entry.Name] = string(content)
+			}
+			require.Equal(t, map[string]string{
+				"config.txt":   "configuration",
+				"previous.zip": "previous backup",
+			}, files)
+		})
+	}
+}


### PR DESCRIPTION
When a custom-directory backup is stored inside its source tree, the ZIP walker reads the archive it is still writing and includes that unfinished output in the backup. Skip the output file by file identity, including hard-link aliases, while retaining existing backup files and normal source contents.

Regression tests cover destinations at the source root, in a subdirectory, outside the source, and through a hard link. The root and nested cases fail on unchanged `dev`. The backup guide explains the exclusion and recommends separate storage to avoid including previous archives.

Validation: full uncached race-enabled Go suite (`GOWORK=off go test -tags=unembed -race -cover -count=1 ./...`) and focused backup tests.

AI assistance: implemented and locally tested with Codex. No human review is claimed.
