### PR TITLE
fix(sitecheck): bracket IPv6 hosts when adding the default gRPC port

### DIFF
--- a/internal/sitecheck/checker_test.go
+++ b/internal/sitecheck/checker_test.go
@@ -132,6 +132,33 @@ func TestRewriteCheckURLSchemeHonorsConfiguredProtocol(t *testing.T) {
 	}
 }
 
+func TestParseGRPCURLDefaultPort(t *testing.T) {
+	cases := []struct {
+		url  string
+		want string
+	}{
+		{"grpc://example.com", "example.com:80"},
+		{"grpcs://example.com", "example.com:443"},
+		{"grpc://example.com:50051", "example.com:50051"},
+		{"grpc://[2001:db8::1]", "[2001:db8::1]:80"},
+		{"grpcs://[2001:db8::1]", "[2001:db8::1]:443"},
+		{"https://[::1]/health", "[::1]:443"},
+		{"grpc://[2001:db8::1]:50051", "[2001:db8::1]:50051"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.url, func(t *testing.T) {
+			parsed, err := parseGRPCURL(tc.url)
+			if err != nil {
+				t.Fatalf("parseGRPCURL(%q) error = %v", tc.url, err)
+			}
+			if parsed.Host != tc.want {
+				t.Fatalf("parseGRPCURL(%q).Host = %q, want %q", tc.url, parsed.Host, tc.want)
+			}
+		})
+	}
+}
+
 func TestCheckSiteWithConfigRewritesURLScheme(t *testing.T) {
 	t.Cleanup(InvalidateSiteConfigCache)
 

--- a/internal/sitecheck/enhanced_checker.go
+++ b/internal/sitecheck/enhanced_checker.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"slices"
@@ -389,17 +390,19 @@ func parseGRPCURL(rawURL string) (*url.URL, error) {
 		Host:   parsedURL.Host,
 	}
 
-	// If no port is specified, use default ports based on original scheme
+	// If no port is specified, use default ports based on original scheme.
+	// Hostname() strips the brackets of an IPv6 literal, so JoinHostPort puts
+	// them back; otherwise [::1] would become the unparsable target ::1:443.
 	if parsedURL.Port() == "" {
 		switch parsedURL.Scheme {
 		case "https":
-			grpcURL.Host = parsedURL.Hostname() + ":443"
+			grpcURL.Host = net.JoinHostPort(parsedURL.Hostname(), "443")
 		case "http":
-			grpcURL.Host = parsedURL.Hostname() + ":80"
+			grpcURL.Host = net.JoinHostPort(parsedURL.Hostname(), "80")
 		case "grpcs":
-			grpcURL.Host = parsedURL.Hostname() + ":443"
+			grpcURL.Host = net.JoinHostPort(parsedURL.Hostname(), "443")
 		case "grpc":
-			grpcURL.Host = parsedURL.Hostname() + ":80"
+			grpcURL.Host = net.JoinHostPort(parsedURL.Hostname(), "80")
 		default:
 			// For URLs without scheme, default to port 80
 			grpcURL.Host = parsedURL.Host + ":80"


### PR DESCRIPTION
After #1882 fixed IPv6 parsing in `SiteConfig.SetFromURL`, I checked the rest of the site check code for the same pattern. `parseGRPCURL`, which gives the gRPC health probe its dial target, has it too.

When the URL has no port, it builds the target as `parsedURL.Hostname() + ":443"` (or `":80"`). `Hostname()` removes the brackets from an IPv6 literal, so `grpcs://[2001:db8::1]` turns into `2001:db8::1:443`. That isn't a valid host:port, so a gRPC health check pointed at an IPv6 address without an explicit port can't reach it. URLs that already include a port were fine because `parsedURL.Host` keeps the brackets.

The fix uses `net.JoinHostPort` in the four scheme branches. I didn't change the scheme-less fallback: it appends to `parsedURL.Host`, which still has its brackets.

I added `TestParseGRPCURLDefaultPort` next to the existing `rewriteCheckURLScheme` test. It covers hostnames and IPv6 literals, with and without a port. Before the fix, the three IPv6 cases without a port fail:

```
parseGRPCURL("grpc://[2001:db8::1]").Host = "2001:db8::1:80", want "[2001:db8::1]:80"
parseGRPCURL("grpcs://[2001:db8::1]").Host = "2001:db8::1:443", want "[2001:db8::1]:443"
parseGRPCURL("https://[::1]/health").Host = "::1:443", want "[::1]:443"
```

With the fix, they all pass. `GOWORK=off go test -tags=unembed -race -cover -count=1 ./internal/sitecheck/ ./model/` passes and gofmt is clean. I only tested this at the unit level. I didn't run a real gRPC server on an IPv6 address on port 443.

AI tools used
